### PR TITLE
fix(terraform): default new alert vars to empty to unblock Pass-1 apply

### DIFF
--- a/terraform/environments/variables.tf
+++ b/terraform/environments/variables.tf
@@ -136,23 +136,30 @@ variable "new_relic_worker_app_name" {
 variable "new_relic_browser_app_name" {
   description = "New Relic Browser entity name for the web frontend (NEXT_PUBLIC_NEW_RELIC_BROWSER_APPLICATION_ID's app)."
   type        = string
+  # Empty default so the Pass-1 (-target=module.bootstrap) apply, which does
+  # not pass these vars, doesn't block on an interactive prompt. The real
+  # value is supplied via -var in the Pass-2/3 full applies.
+  default = ""
 }
 
 variable "new_relic_account_id" {
   description = "New Relic account ID, used by the newrelic Terraform provider to manage alert policies."
   type        = string
+  default     = ""
 }
 
 variable "new_relic_api_key" {
   description = "New Relic User API key (NRAK-...) used by the newrelic Terraform provider."
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "discord_alert_webhook_url" {
   description = "Discord incoming webhook URL that receives application alert notifications (separate channel from CI/CD alerts)."
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "api_base_url" {


### PR DESCRIPTION
## Problem
The stage `deploy-backend.yml` hung for 25 minutes on the **Terraform apply (platform only)** step (Pass 1). Cancelled run logs show it blocked waiting on an interactive prompt:

```
Acquiring state lock. This may take a few moments...
var.discord_alert_webhook_url
  Discord incoming webhook URL that receives application alert notifications...
```

Pass 1 runs `terraform apply -target=module.bootstrap` and does **not** pass the new alert vars. Because `new_relic_account_id`, `new_relic_api_key`, `new_relic_browser_app_name`, and `discord_alert_webhook_url` had no `default`, Terraform prompted for them and hung (no TTY in CI).

This also explains the readiness-monitor Discord alerts: since no deploy since 7/6 succeeded, `SYNTHIFY_READINESS_MONITOR_KEY` was never written to Cloud Run, so `/health?ready=1` returned 401.

## Fix
Give the four new variables `default = ""`, matching every other per-pass var (`readiness_api_key`, `api_base_url`, etc.). The real values are still supplied via `-var` in the Pass-2/3 full applies, where `module.monitoring` is actually created.

## Test plan
- [x] `terraform validate` (environments root)
- [x] `terraform fmt`
- [ ] Re-run stage deploy and confirm Pass 1 no longer hangs
- [ ] Confirm readiness-monitor turns green after the deploy writes the monitor key