### PR TITLE
Expand AI contract and evaluation tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - apps/api/**
+      - apps/eval/**
       - apps/worker/**
       - internal/platform/**
       - go.mod
@@ -15,6 +16,7 @@ on:
       - main
     paths:
       - apps/api/**
+      - apps/eval/**
       - apps/worker/**
       - internal/platform/**
       - go.mod

--- a/apps/worker/pkg/worker/agents/evaluator.go
+++ b/apps/worker/pkg/worker/agents/evaluator.go
@@ -8,6 +8,8 @@ import (
 	"github.com/synthify/backend/apps/worker/pkg/worker/llm"
 )
 
+const evaluationPassScore = 70
+
 type Evaluator struct {
 	llm llm.Client
 }
@@ -48,5 +50,13 @@ Return findings as a list of specific issues found.`,
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil, fmt.Errorf("parse evaluation result: %w", err)
 	}
+	if out.Score < 0 || out.Score > 100 {
+		return nil, fmt.Errorf("invalid evaluation score %d: must be between 0 and 100", out.Score)
+	}
+
+	// Do not trust the model to keep its boolean consistent with the numeric
+	// score. The score is the canonical value and the pass threshold is enforced
+	// deterministically so contradictory model output cannot pass evaluation.
+	out.Passed = out.Score >= evaluationPassScore
 	return &out, nil
 }

--- a/apps/worker/pkg/worker/agents/evaluator_test.go
+++ b/apps/worker/pkg/worker/agents/evaluator_test.go
@@ -1,0 +1,110 @@
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/synthify/backend/apps/worker/pkg/worker/llm"
+)
+
+type evaluatorFakeLLM struct {
+	raw json.RawMessage
+	err error
+	req llm.StructuredRequest
+}
+
+func (f *evaluatorFakeLLM) GenerateStructured(_ context.Context, req llm.StructuredRequest) (json.RawMessage, llm.Usage, error) {
+	f.req = req
+	return f.raw, llm.Usage{Model: "fake-evaluator"}, f.err
+}
+
+func (f *evaluatorFakeLLM) GenerateText(context.Context, llm.TextRequest) (string, llm.Usage, error) {
+	return "", llm.Usage{}, errors.New("unexpected GenerateText call")
+}
+
+func TestEvaluateTree_DerivesPassedFromScore(t *testing.T) {
+	tests := []struct {
+		name        string
+		score       int
+		modelPassed bool
+		wantPassed  bool
+	}{
+		{name: "below threshold overrides true", score: 69, modelPassed: true, wantPassed: false},
+		{name: "threshold overrides false", score: 70, modelPassed: false, wantPassed: true},
+		{name: "above threshold passes", score: 95, modelPassed: true, wantPassed: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := json.Marshal(evaluationOutput{
+				Score:    tt.score,
+				Passed:   tt.modelPassed,
+				Summary:  "summary",
+				Findings: []string{"finding"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			fake := &evaluatorFakeLLM{raw: raw}
+
+			out, err := NewEvaluator(fake).EvaluateTree(context.Background(), `{"items":[]}`)
+			if err != nil {
+				t.Fatalf("EvaluateTree returned error: %v", err)
+			}
+			if out.Passed != tt.wantPassed {
+				t.Fatalf("Passed = %v, want %v (score=%d, model passed=%v)", out.Passed, tt.wantPassed, tt.score, tt.modelPassed)
+			}
+			if out.Score != tt.score {
+				t.Fatalf("Score = %d, want %d", out.Score, tt.score)
+			}
+			if !strings.Contains(fake.req.UserPrompt, `{"items":[]}`) {
+				t.Fatalf("tree data missing from user prompt: %q", fake.req.UserPrompt)
+			}
+			if _, ok := fake.req.Schema.(evaluationOutput); !ok {
+				t.Fatalf("Schema type = %T, want evaluationOutput", fake.req.Schema)
+			}
+		})
+	}
+}
+
+func TestEvaluateTree_RejectsOutOfRangeScore(t *testing.T) {
+	for _, score := range []int{-1, 101} {
+		t.Run(string(rune(score+128)), func(t *testing.T) {
+			raw, err := json.Marshal(evaluationOutput{Score: score})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = NewEvaluator(&evaluatorFakeLLM{raw: raw}).EvaluateTree(context.Background(), `{}`)
+			if err == nil || !strings.Contains(err.Error(), "must be between 0 and 100") {
+				t.Fatalf("expected range error for score %d, got %v", score, err)
+			}
+		})
+	}
+}
+
+func TestEvaluateTree_RejectsMalformedJSON(t *testing.T) {
+	_, err := NewEvaluator(&evaluatorFakeLLM{raw: json.RawMessage(`{"score":`)}).EvaluateTree(context.Background(), `{}`)
+	if err == nil || !strings.Contains(err.Error(), "parse evaluation result") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+func TestEvaluateTree_WrapsLLMError(t *testing.T) {
+	_, err := NewEvaluator(&evaluatorFakeLLM{err: errors.New("provider unavailable")}).EvaluateTree(context.Background(), `{}`)
+	if err == nil || !strings.Contains(err.Error(), "evaluate tree: provider unavailable") {
+		t.Fatalf("expected wrapped provider error, got %v", err)
+	}
+}
+
+func TestEvaluateTree_NilClientReturnsExplicitFailure(t *testing.T) {
+	out, err := NewEvaluator(nil).EvaluateTree(context.Background(), `{}`)
+	if err != nil {
+		t.Fatalf("EvaluateTree returned error: %v", err)
+	}
+	if out.Score != 0 || out.Passed || out.Summary != "LLM not configured" {
+		t.Fatalf("unexpected nil-client result: %#v", out)
+	}
+}

--- a/apps/worker/pkg/worker/agents/evaluator_test.go
+++ b/apps/worker/pkg/worker/agents/evaluator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -72,7 +73,7 @@ func TestEvaluateTree_DerivesPassedFromScore(t *testing.T) {
 
 func TestEvaluateTree_RejectsOutOfRangeScore(t *testing.T) {
 	for _, score := range []int{-1, 101} {
-		t.Run(string(rune(score+128)), func(t *testing.T) {
+		t.Run(fmt.Sprintf("score_%d", score), func(t *testing.T) {
 			raw, err := json.Marshal(evaluationOutput{Score: score})
 			if err != nil {
 				t.Fatal(err)

--- a/apps/worker/pkg/worker/agents/evaluator_test.matrix.md
+++ b/apps/worker/pkg/worker/agents/evaluator_test.matrix.md
@@ -1,0 +1,92 @@
+# テストマトリクス: `evaluator_test.go`
+
+このマトリクスは、`evaluator_test.go` の各テストケースが何を保証していて、何を意図的にカバーしていないかを確認するための表です。
+
+> **読み方の注意**: 下の「テストケース表」は既存テストが確認している内容を写したものです。
+> テストがない分岐は表に現れないため、「インターフェース網羅チェック」「依存エラー軸」「未テスト分岐 (GAP)」も併読してください。
+> カバレッジ数値は未計測 (2026-07-18)。実測時は `go test -coverprofile` の値へ更新すること。
+
+ステータス:
+
+| ステータス | 意味 |
+| --- | --- |
+| OK | 主要な挙動はこのテストファイルで担保している。 |
+| PARTIAL | 有用な挙動は担保しているが、重要な境界値や統合経路はこのファイルの外に残っている。 |
+| GAP | 必要な確認観点だが、現時点ではテストで担保されていない。 |
+
+## インターフェース網羅チェック (`Evaluator`)
+
+| メソッド / 経路 | 専用テスト | coverage | 状態 | 未テストの主分岐 |
+| --- | --- | --- | --- | --- |
+| `NewEvaluator` | ◐ 各テストの setup で使用 | 未計測 | PARTIAL | constructor 単体の確認はないが、状態を持たないため優先度は低い。 |
+| `EvaluateTree`: 正常な構造化出力 | ✅ 3 subtests | 未計測 | OK | summary/findings の内容品質、空文字列の扱い。 |
+| `EvaluateTree`: score→passed の決定論的判定 | ✅ 3 subtests | 未計測 | OK | 閾値変更時の設定化。 |
+| `EvaluateTree`: score 範囲 validation | ✅ 2 subtests | 未計測 | OK | 極端な整数、型違い、score 欠落。 |
+| `EvaluateTree`: JSON parse error | ✅ 1件 | 未計測 | OK | schema 上の必須フィールド欠落、未知フィールド。 |
+| `EvaluateTree`: LLM dependency error | ✅ 1件 | 未計測 | OK | context cancellation / deadline、rate limit の型付き error。 |
+| `EvaluateTree`: nil LLM | ✅ 1件 | 未計測 | OK | nil を error とするか結果として返すかの仕様変更。 |
+
+## 依存エラー軸 (dependency returns error)
+
+`Evaluator` の外部依存は `llm.Client.GenerateStructured`。☑=テスト有 / ◐=間接 / ❌=未テスト。
+
+| メソッド | provider error | malformed response | context canceled | deadline exceeded | rate limit / retryable error |
+| --- | --- | --- | --- | --- | --- |
+| `EvaluateTree` | ☑ `TestEvaluateTree_WrapsLLMError` | ☑ `TestEvaluateTree_RejectsMalformedJSON` | ❌ | ❌ | ❌ |
+
+→ Provider error のラップは確認済みだが、呼び出しキャンセルと provider error classification は未確認。
+
+## 未テスト分岐 (GAP) — テストケース表に現れない経路
+
+| 場所 | 分岐 | 期待挙動 | なぜ重要か |
+| --- | --- | --- | --- |
+| `evaluator.go:EvaluateTree` | `score` フィールド欠落 | 欠落を schema error として拒否するか、0点として扱うかを仕様化する。 | 現状は Go の zero value により静かに0点となる。Providerのschema保証が崩れた際に検知しにくい。 |
+| `evaluator.go:EvaluateTree` | `summary` / `findings` 欠落または空 | 必須性と最小品質を検証する。 | scoreだけの評価ではレビュー理由が残らない。 |
+| `evaluator.go:EvaluateTree` | context canceled / deadline exceeded | 元errorを保持して速やかに返す。 | Worker停止・予算超過時に評価処理が残留するのを防ぐ。 |
+| `evaluator.go:EvaluateTree` | 巨大な `treeData` | 入力上限またはchunking方針を適用する。 | token超過、遅延、コスト増加の防止。 |
+| `evaluator.go:EvaluateTree` | findings が極端に多い / 長い | 件数・長さ上限を適用する。 | DB・ログ・UIへの過大データ流入を防ぐ。 |
+
+| チェック | テストケース | 対象 | 観点 | セットアップ / 入力 | 期待結果 | 副作用 / 状態変化 | 主要 assertion | カバーしていること | カバーしていないこと | 追加候補 | ステータス |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| [ ] | `TestEvaluateTree_DerivesPassedFromScore/below_threshold_overrides_true` | `EvaluateTree` | 矛盾出力 / 閾値 | model が `score=69, passed=true` を返す。 | `Passed=false`。 | なし。 | `out.Passed == false`, `out.Score == 69` | model booleanを信用せずscoreを正とすること。 | score欠落、型違い。 | `score` missing / string のschema error。 | OK |
+| [ ] | `TestEvaluateTree_DerivesPassedFromScore/threshold_overrides_false` | `EvaluateTree` | 境界値 | model が `score=70, passed=false` を返す。 | `Passed=true`。 | なし。 | `out.Passed == true`, `out.Score == 70` | 合格閾値ちょうど70を許可すること。 | 71や100の境界。 | 100点と0点の明示テスト。 | OK |
+| [ ] | `TestEvaluateTree_DerivesPassedFromScore/above_threshold_passes` | `EvaluateTree` | 正常系 | model が `score=95, passed=true` を返す。 | scoreと合否を保持する。 | なし。 | `Passed`, `Score`, prompt, schema type | 正常な高評価、tree入力のprompt注入、schema指定。 | summary/findingsの内容品質。 | summary/findingsの保持assertion。 | PARTIAL |
+| [ ] | `TestEvaluateTree_RejectsOutOfRangeScore/score_-1` | `EvaluateTree` | 数値下限 | `score=-1`。 | range error。 | なし。 | error contains `must be between 0 and 100` | 負数を拒否すること。 | 最小int。 | 極端な負数。 | OK |
+| [ ] | `TestEvaluateTree_RejectsOutOfRangeScore/score_101` | `EvaluateTree` | 数値上限 | `score=101`。 | range error。 | なし。 | error contains range message | 100超過を拒否すること。 | 最大int。 | 極端な正数。 | OK |
+| [ ] | `TestEvaluateTree_RejectsMalformedJSON` | `EvaluateTree` | response parse | Providerが途中で切れたJSONを返す。 | `parse evaluation result` error。 | なし。 | error message | 壊れた構造化出力を成功扱いしないこと。 | valid JSONだがschema不整合。 | 欠落・型違い・unknown field。 | PARTIAL |
+| [ ] | `TestEvaluateTree_WrapsLLMError` | `EvaluateTree` | dependency error | Providerが`provider unavailable`を返す。 | `evaluate tree:`でwrapされたerror。 | なし。 | wrapped message | Provider障害を文脈付きで伝播すること。 | `errors.Is`、型付きretryable判定。 | sentinel errorを使う`errors.Is`テスト。 | PARTIAL |
+| [ ] | `TestEvaluateTree_NilClientReturnsExplicitFailure` | `EvaluateTree` | nil dependency | `NewEvaluator(nil)`。 | errorなし、0点、不合格、明示summary。 | なし。 | score / passed / summary | LLM未設定をpanicさせず評価不能として返すこと。 | 呼び出し元がこの結果をどう扱うか。 | Worker統合で評価不能のstatus確認。 | PARTIAL |
+
+## 観点別チェックグリッド
+
+| テストケース | 正常系 | 異常系 | 境界値 | 構造化出力 | 矛盾防止 | dependency mock | error wrapping | prompt / schema | 非同期 / cancellation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `TestEvaluateTree_DerivesPassedFromScore` | ☑ | ◐ | ☑ | ☑ | ☑ | ☑ | - | ☑ | - |
+| `TestEvaluateTree_RejectsOutOfRangeScore` | - | ☑ | ☑ | ☑ | ☑ | ☑ | - | - | - |
+| `TestEvaluateTree_RejectsMalformedJSON` | - | ☑ | - | ☑ | - | ☑ | ☑ | - | - |
+| `TestEvaluateTree_WrapsLLMError` | - | ☑ | - | - | - | ☑ | ☑ | - | - |
+| `TestEvaluateTree_NilClientReturnsExplicitFailure` | - | ☑ | - | - | - | ☑ | - | - | - |
+
+## 観点別の穴
+
+| 観点 | 現状 | 追加するとよいチェック |
+| --- | --- | --- |
+| schema厳格性 | malformed JSONのみ確認。 | field欠落、型違い、unknown fieldを拒否できるschema validation。 |
+| cancellation | 未確認。 | canceled context / expired deadlineがProviderへ渡り、元errorを保持すること。 |
+| 評価説明 | scoreとpassedのみ重点確認。 | summary/findingsの保持、空値拒否、件数上限。 |
+| 入力サイズ | 未確認。 | 巨大treeDataの上限、truncate/chunkingの仕様。 |
+| integration | fake LLMのみ。 | Worker経路で評価結果がstatus/logへ反映されるテスト。 |
+
+## 境界値チェックマトリクス
+
+### score
+
+| 対象値 / 条件 | `-1` | `0` | `69` | `70` | `71` | `100` | `101` | missing | wrong type | 対応テスト | 不足 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| evaluation score | ☑ | ◐ nil-client経由 | ☑ | ☑ | ◐ 95で代表 | ◐ 95で代表 | ☑ | - | - | `TestEvaluateTree_DerivesPassedFromScore`, `TestEvaluateTree_RejectsOutOfRangeScore`, `TestEvaluateTree_NilClientReturnsExplicitFailure` | 0、71、100、missing、string/nullを直接確認。 |
+
+### treeData
+
+| 対象値 / 条件 | empty | valid JSON | malformed JSON text | whitespace | huge | secret-like content | 対応テスト | 不足 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `treeData` input | - | ☑ | - | - | - | - | `TestEvaluateTree_DerivesPassedFromScore` | empty/whitespace、巨大入力、機密情報をログへ出さないこと。 |

--- a/apps/worker/pkg/worker/tools/builtin/process/knowledge_tree_test.go
+++ b/apps/worker/pkg/worker/tools/builtin/process/knowledge_tree_test.go
@@ -1,0 +1,180 @@
+package process
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/synthify/backend/apps/worker/pkg/worker/domain"
+	"github.com/synthify/backend/apps/worker/pkg/worker/llm"
+	"github.com/synthify/backend/apps/worker/pkg/worker/tools/core/base"
+)
+
+type knowledgeTreeFakeLLM struct {
+	raw   json.RawMessage
+	usage llm.Usage
+	err   error
+	req   llm.StructuredRequest
+}
+
+func (f *knowledgeTreeFakeLLM) GenerateStructured(_ context.Context, req llm.StructuredRequest) (json.RawMessage, llm.Usage, error) {
+	f.req = req
+	return f.raw, f.usage, f.err
+}
+
+func (f *knowledgeTreeFakeLLM) GenerateText(context.Context, llm.TextRequest) (string, llm.Usage, error) {
+	return "", llm.Usage{}, errors.New("unexpected GenerateText call")
+}
+
+func TestGenerateKnowledgeTree_ObjectResponseAndUsage(t *testing.T) {
+	want := domain.GeneratedTreeItem{
+		LocalID:        "item_1",
+		Title:          "Authentication",
+		Level:          1,
+		Description:    "Token lifecycle",
+		Content:        "<p>Token lifecycle</p>",
+		SourceChunkIDs: []string{"doc_1_chunk_0"},
+	}
+	raw, err := json.Marshal(GenerateKnowledgeTreeResult{Items: []domain.GeneratedTreeItem{want}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := &knowledgeTreeFakeLLM{
+		raw:   raw,
+		usage: llm.Usage{Model: "fake-model", InputTokens: 12, OutputTokens: 34},
+	}
+
+	items, usage, err := GenerateKnowledgeTree(context.Background(), fake, GenerateKnowledgeTreeArgs{
+		DocumentID: "doc_1",
+		Chunks: []domain.Chunk{{ChunkIndex: 0, Heading: "Authentication", Text: "Tokens expire."}},
+	})
+	if err != nil {
+		t.Fatalf("GenerateKnowledgeTree returned error: %v", err)
+	}
+	if len(items) != 1 || items[0].Title != want.Title || items[0].LocalID != want.LocalID {
+		t.Fatalf("unexpected items: %#v", items)
+	}
+	if usage != fake.usage {
+		t.Fatalf("usage = %#v, want %#v", usage, fake.usage)
+	}
+	if strings.TrimSpace(fake.req.SystemPrompt) == "" || strings.TrimSpace(fake.req.UserPrompt) == "" {
+		t.Fatalf("rendered prompts must be non-empty: %#v", fake.req)
+	}
+	if fake.req.Schema == nil {
+		t.Fatal("structured request must include an output schema")
+	}
+}
+
+func TestGenerateKnowledgeTree_AcceptsTopLevelArray(t *testing.T) {
+	want := []domain.GeneratedTreeItem{{
+		LocalID:        "item_1",
+		Title:          "認証",
+		Level:          1,
+		Description:    "認証方式",
+		Content:        "<p>認証方式</p>",
+		SourceChunkIDs: []string{"doc_1_chunk_0"},
+	}}
+	raw, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items, _, err := GenerateKnowledgeTree(context.Background(), &knowledgeTreeFakeLLM{raw: raw}, GenerateKnowledgeTreeArgs{
+		DocumentID: "doc_1",
+		Chunks:     []domain.Chunk{{ChunkIndex: 0, Heading: "認証", Text: "OAuthを使う。"}},
+	})
+	if err != nil {
+		t.Fatalf("GenerateKnowledgeTree returned error: %v", err)
+	}
+	if len(items) != 1 || items[0].Title != "認証" {
+		t.Fatalf("unexpected items: %#v", items)
+	}
+}
+
+func TestGenerateKnowledgeTree_RejectsMalformedJSON(t *testing.T) {
+	_, _, err := GenerateKnowledgeTree(context.Background(), &knowledgeTreeFakeLLM{raw: json.RawMessage(`{"items":`)}, GenerateKnowledgeTreeArgs{
+		DocumentID: "doc_1",
+		Chunks:     []domain.Chunk{{ChunkIndex: 0, Text: "content"}},
+	})
+	if err == nil {
+		t.Fatal("expected malformed JSON error")
+	}
+}
+
+func TestGenerateKnowledgeTree_RejectsEmptyItems(t *testing.T) {
+	_, _, err := GenerateKnowledgeTree(context.Background(), &knowledgeTreeFakeLLM{raw: json.RawMessage(`{"items":[]}`)}, GenerateKnowledgeTreeArgs{
+		DocumentID: "doc_1",
+		Chunks:     []domain.Chunk{{ChunkIndex: 0, Text: "content"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "llm returned no items") {
+		t.Fatalf("expected empty-items error, got %v", err)
+	}
+}
+
+func TestGenerateKnowledgeTreeTool_FallsBackOnLLMError(t *testing.T) {
+	fake := &knowledgeTreeFakeLLM{
+		usage: llm.Usage{Model: "fake-model", InputTokens: 7, OutputTokens: 0},
+		err:   errors.New("provider unavailable"),
+	}
+	tool, err := NewGenerateKnowledgeTreeTool(&base.Context{LLM: fake})
+	if err != nil {
+		t.Fatalf("NewGenerateKnowledgeTreeTool: %v", err)
+	}
+	input, err := json.Marshal(GenerateKnowledgeTreeArgs{
+		DocumentID: "doc_1",
+		Chunks: []domain.Chunk{{
+			ChunkIndex: 0,
+			Heading:    "",
+			Text:       `<script>alert("x")</script>`,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, usage, err := tool.Run(context.Background(), input)
+	if err != nil {
+		t.Fatalf("tool.Run returned error: %v", err)
+	}
+	var out GenerateKnowledgeTreeResult
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(out.Items) != 1 {
+		t.Fatalf("fallback item count = %d, want 1", len(out.Items))
+	}
+	item := out.Items[0]
+	if item.Title != "Section 1" {
+		t.Fatalf("fallback title = %q, want Section 1", item.Title)
+	}
+	if item.Content != `<p>&lt;script&gt;alert(&#34;x&#34;)&lt;/script&gt;</p>` {
+		t.Fatalf("fallback content was not escaped: %q", item.Content)
+	}
+	if len(item.SourceChunkIDs) != 1 || item.SourceChunkIDs[0] != "doc_1_chunk_0" {
+		t.Fatalf("unexpected source chunk ids: %#v", item.SourceChunkIDs)
+	}
+	if usage.Model != fake.usage.Model || usage.InputTokens != fake.usage.InputTokens || usage.OutputTokens != fake.usage.OutputTokens {
+		t.Fatalf("usage = %#v, want %#v", usage, fake.usage)
+	}
+}
+
+func TestGenerateKnowledgeTree_ReturnsProviderErrorAndUsage(t *testing.T) {
+	providerErr := errors.New("rate limited")
+	fake := &knowledgeTreeFakeLLM{
+		usage: llm.Usage{Model: "fake-model", InputTokens: 21},
+		err:   providerErr,
+	}
+
+	_, usage, err := GenerateKnowledgeTree(context.Background(), fake, GenerateKnowledgeTreeArgs{
+		DocumentID: "doc_1",
+		Chunks:     []domain.Chunk{{ChunkIndex: 0, Text: "content"}},
+	})
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("error = %v, want provider error", err)
+	}
+	if usage != fake.usage {
+		t.Fatalf("usage = %#v, want %#v", usage, fake.usage)
+	}
+}

--- a/apps/worker/pkg/worker/tools/builtin/process/knowledge_tree_test.matrix.md
+++ b/apps/worker/pkg/worker/tools/builtin/process/knowledge_tree_test.matrix.md
@@ -1,0 +1,112 @@
+# テストマトリクス: `knowledge_tree_test.go`
+
+このマトリクスは、`knowledge_tree_test.go` の各テストケースが何を保証していて、何を意図的にカバーしていないかを確認するための表です。
+
+> **読み方の注意**: 下の「テストケース表」は既存テストが確認している内容を写したものです。
+> テストがない関数・分岐は表に現れないため、「インターフェース網羅チェック」「依存エラー軸」「未テスト分岐 (GAP)」も併読してください。
+> カバレッジ数値は未計測 (2026-07-18)。実測時は `go test -coverprofile` の値へ更新すること。
+
+ステータス:
+
+| ステータス | 意味 |
+| --- | --- |
+| OK | 主要な挙動はこのテストファイルで担保している。 |
+| PARTIAL | 有用な挙動は担保しているが、重要な境界値や統合経路はこのファイルの外に残っている。 |
+| GAP | 必要な確認観点だが、現時点ではテストで担保されていない。 |
+
+## インターフェース網羅チェック (`knowledge_tree.go`)
+
+| 関数 / 経路 | 専用テスト | coverage | 状態 | 未テストの主分岐 |
+| --- | --- | --- | --- | --- |
+| `NewGenerateKnowledgeTreeTool` | ✅ 1件 | 未計測 | PARTIAL | repositoryから既存treeを取得する成功/失敗、入力JSON不正、marshal error。 |
+| `GenerateKnowledgeTree` | ✅ 5件 | 未計測 | OK | production prompt loader失敗。 |
+| `GenerateKnowledgeTreeWithRenderer` | ◐ `GenerateKnowledgeTree`経由 | 未計測 | PARTIAL | nil renderer、renderer.Render error、明示variant renderer。 |
+| `generateKnowledgeTree` | ❌ なし | 未計測 | GAP | 薄いwrapperだが直接の回帰確認なし。 |
+| `deterministicKnowledgeTree` | ◐ tool fallback経由 | 未計測 | PARTIAL | 複数chunk、見出しあり、360 rune truncate、非連番chunk index。 |
+| object形式 `{items:[...]}` parse | ✅ 1件 | 未計測 | OK | extra fields、null items。 |
+| top-level array parse | ✅ 1件 | 未計測 | OK | empty arrayは別テストでobject形式のみ。 |
+| malformed / empty LLM output | ✅ 2件 | 未計測 | OK | tool wrapper経由でのfallbackはprovider errorだけ。 |
+| usage propagation | ✅ 3件 | 未計測 | OK | fallback後の課金・telemetry分類。 |
+
+## 依存エラー軸 (dependency returns error)
+
+外部依存は `llm.Client`、`prompts.Renderer`、`base.Context.Repo`。☑=テスト有 / ◐=間接 / ❌=未テスト。
+
+| 関数 | LLM error | malformed LLM response | prompt load/render error | repository error | context canceled / deadline |
+| --- | --- | --- | --- | --- | --- |
+| `GenerateKnowledgeTree` | ☑ `TestGenerateKnowledgeTree_ReturnsProviderErrorAndUsage` | ☑ malformed / empty | ❌ | - | ❌ |
+| `GenerateKnowledgeTreeWithRenderer` | ◐ default renderer経由 | ◐ | ❌ | - | ❌ |
+| `NewGenerateKnowledgeTreeTool.Run` | ☑ fallback確認 | ◐ provider errorのみ | ❌ | ❌ | ❌ |
+
+→ LLM errorの直接伝播とtool fallbackは確認済み。renderer/repository/cancellation軸は未確認。
+
+## 未テスト分岐 (GAP) — テストケース表に現れない経路
+
+| 場所 | 分岐 | 期待挙動 | なぜ重要か |
+| --- | --- | --- | --- |
+| `NewGenerateKnowledgeTreeTool.Run` | 入力JSONのunmarshal失敗 | errorを返し、LLMを呼ばない。 | Agentが不正tool argsを生成した際の安全な失敗。 |
+| `NewGenerateKnowledgeTreeTool.Run` | `Repo.GetTreeByWorkspace`成功 | 既存nodeを`ExistingNodes`としてpromptへ渡す。 | 重複nodeを作らずmerge判断する主要機能。 |
+| `NewGenerateKnowledgeTreeTool.Run` | `Repo.GetTreeByWorkspace`失敗 | best effortで既存nodeなしとして生成を継続する。 | repository一時障害でjob全体を落とさない現行仕様。 |
+| `GenerateKnowledgeTreeWithRenderer` | nil LLM | `llm not configured` error。 | provider初期化漏れの明示検知。 |
+| `GenerateKnowledgeTreeWithRenderer` | nil renderer | `prompt renderer not configured` error。 | variant/eval wiring不備の明示検知。 |
+| `GenerateKnowledgeTreeWithRenderer` | renderer.Render error | errorをそのまま返し、LLMを呼ばない。 | prompt template破損をProvider障害と混同しない。 |
+| `NewGenerateKnowledgeTreeTool.Run` | malformed JSON / empty items | 決定論的fallbackへ移行する。 | ProviderがHTTP成功で壊れた出力を返すケース。 |
+| `deterministicKnowledgeTree` | 360 rune超過 | descriptionをtruncateしHTMLも同値から生成する。 | fallbackで過大contentが保存されるのを防ぐ。 |
+| `deterministicKnowledgeTree` | 複数chunk /非連番index | local/source IDが衝突せず入力indexに対応する。 | chunking結果が必ず0始まり連番とは限らない。 |
+
+| チェック | テストケース | 対象 | 観点 | セットアップ / 入力 | 期待結果 | 副作用 / 状態変化 | 主要 assertion | カバーしていること | カバーしていないこと | 追加候補 | ステータス |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| [ ] | `TestGenerateKnowledgeTree_ObjectResponseAndUsage` | `GenerateKnowledgeTree` | 正常系 / structured output / usage | Fake LLMが`{"items":[...]}`とtoken usageを返す。 | itemを1件返しusageを保持する。 | なし。 | item title/localID、usage一致、prompt非空、schema指定 | production renderer、object response、usage伝播。 | prompt全文、existing nodes、schema実validation。 | promptにchunk/instruction/existing nodeが含まれること。 | PARTIAL |
+| [ ] | `TestGenerateKnowledgeTree_AcceptsTopLevelArray` | `GenerateKnowledgeTree` | compatibility | Fake LLMがtop-level item arrayを返す。 | arrayをitemsとして受理する。 | なし。 | item count/title | 旧/異種Providerのarray出力互換。 | empty array、複数item、nested parent。 | top-level empty arrayと複数階層。 | OK |
+| [ ] | `TestGenerateKnowledgeTree_RejectsMalformedJSON` | `GenerateKnowledgeTree` | parse error | 途中で切れたJSON。 | errorを返す。 | なし。 | `err != nil` | 壊れた構造化出力を成功扱いしない。 | error種別、tool wrapperのfallback。 | error messageとfallback経路を確認。 | PARTIAL |
+| [ ] | `TestGenerateKnowledgeTree_RejectsEmptyItems` | `GenerateKnowledgeTree` | empty output | `{"items":[]}`。 | `llm returned no items` error。 | なし。 | error message | schema-validでも意味的に空の出力を拒否。 | top-level empty array、null。 | `[]`, `{"items":null}`比較。 | PARTIAL |
+| [ ] | `TestGenerateKnowledgeTreeTool_FallsBackOnLLMError` | `NewGenerateKnowledgeTreeTool.Run`, `deterministicKnowledgeTree` | fallback / security / usage | LLM error、空heading、script文字列を含む1chunk。 | toolは成功し、`Section 1` itemを返す。HTMLはescapeされusageを保持。 | fallback item生成。 | title、escaped content、source chunk ID、usage | Provider障害時の継続、XSS文字列escape、fallback ID。 | fallback発生のtelemetry、複数chunk、truncate。 | fallback reasonを結果/ログへ記録するテスト。 | PARTIAL |
+| [ ] | `TestGenerateKnowledgeTree_ReturnsProviderErrorAndUsage` | `GenerateKnowledgeTree` | dependency error / usage | Fake LLMがsentinel errorと部分usageを返す。 | 元errorを保持しusageを返す。 | なし。 | `errors.Is`, usage一致 | direct functionがProvider errorを握りつぶさないこと。 | retry、rate limit分類、cancellation。 | typed provider errorとcontext error。 | PARTIAL |
+
+## 観点別チェックグリッド
+
+| テストケース | 正常系 | 異常系 | structured output | compatibility | prompt / schema | usage | fallback | HTML安全性 | repository | cancellation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `TestGenerateKnowledgeTree_ObjectResponseAndUsage` | ☑ | - | ☑ | - | ☑ | ☑ | - | - | - | - |
+| `TestGenerateKnowledgeTree_AcceptsTopLevelArray` | ☑ | - | ☑ | ☑ | ◐ | - | - | - | - | - |
+| `TestGenerateKnowledgeTree_RejectsMalformedJSON` | - | ☑ | ☑ | - | - | - | - | - | - | - |
+| `TestGenerateKnowledgeTree_RejectsEmptyItems` | - | ☑ | ☑ | - | - | - | - | - | - | - |
+| `TestGenerateKnowledgeTreeTool_FallsBackOnLLMError` | ◐ | ☑ | - | - | - | ☑ | ☑ | ☑ | - | - |
+| `TestGenerateKnowledgeTree_ReturnsProviderErrorAndUsage` | - | ☑ | - | - | - | ☑ | - | - | - | - |
+
+## 観点別の穴
+
+| 観点 | 現状 | 追加するとよいチェック |
+| --- | --- | --- |
+| existing tree merge context | 未確認。 | Repoから既存nodeを取得し、LLM request promptにID/title/descriptionが入ること。 |
+| prompt renderer | default rendererの正常系のみ。 | nil renderer、template error、variant renderer。 |
+| tool input validation | valid JSONのみ。 | malformed JSON、必須ID欠落、空chunks。 |
+| fallback coverage | Provider error1種類のみ。 | malformed JSON、empty items、context error時にfallbackすべきかの仕様化。 |
+| fallback observability | usageのみ保持。 | fallback flag/reasonがlogまたはresultに残ること。 |
+| cancellation / timeout | 未確認。 | canceled contextとdeadline exceededをfallbackせず返すかを決めてテスト。 |
+| tree invariants | item存在のみ。 | local ID一意、parent存在、循環なし、source chunk存在、最大深さ。 |
+| security | fallback HTML escapeのみ。 | LLM生成HTMLのsanitize境界、危険属性、override CSS。 |
+
+## 境界値チェックマトリクス
+
+### item count / chunk count
+
+| 対象値 / 条件 | `0` | `1` | typical multiple | large | malformed/null | 対応テスト | 不足 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| LLM output items | ☑ object形式 | ☑ | - | - | ◐ malformed JSON | `TestGenerateKnowledgeTree_ObjectResponseAndUsage`, `TestGenerateKnowledgeTree_AcceptsTopLevelArray`, `TestGenerateKnowledgeTree_RejectsEmptyItems` | top-level 0、複数item、大量item、null。 |
+| input chunks | - | ☑ | - | - | - | 全正常テスト | 0 chunks、複数chunk、大量chunk。 |
+
+### scoreではなく文字列 / ID / content
+
+| 対象値 / 条件 | empty | whitespace | typical | HTML/script | long > 360 runes | malformed | 対応テスト | 不足 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| chunk heading | ☑ fallbackで空 | - | ☑ | - | - | - | object/array/fallback tests | whitespace-only heading、長大heading。 |
+| chunk text | - | - | ☑ | ☑ fallback escape | - | - | `TestGenerateKnowledgeTreeTool_FallsBackOnLLMError` | empty text、360境界、Unicode truncate。 |
+| document ID | - | - | ☑ | - | - | - | 全テスト | empty/malformed IDとsource ID生成。 |
+| LLM JSON | - | - | ☑ | - | - | ☑ | object/array/malformed tests | null、wrong field type、unknown fields。 |
+
+### usage
+
+| 対象値 / 条件 | `0` | typical | partial usage on error | negative | huge | 対応テスト | 不足 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| input/output tokens | ◐ fallback output=0 | ☑ | ☑ | - | - | object/usage、fallback、provider error tests | both zero、negative防止、overflow、Provider別usage semantics。 |


### PR DESCRIPTION
## What changed

- add contract tests for `GenerateKnowledgeTree` object and top-level array responses
- cover malformed JSON, empty output, provider errors, usage propagation, and deterministic fallback escaping
- make evaluator pass/fail deterministic from the numeric score instead of trusting a potentially contradictory model boolean
- validate evaluator scores stay within 0–100 and add malformed-output/provider-error tests
- add `evaluator_test.matrix.md` and `knowledge_tree_test.matrix.md` following the `apps/api` test-matrix format
- document dependency-error axes, uncovered branches, boundary cases, and follow-up test candidates
- run backend CI when `apps/eval/**` changes

## Why

The existing eval infrastructure is useful, but the highest-risk AI boundaries were not covered directly: structured-output parsing, fallback behavior, evaluator contradictions, and provider usage/error propagation. These tests make those behaviors deterministic and provider-neutral before adding a Codex implementation.

The matrix documents make the remaining gaps explicit instead of treating the newly added tests as complete coverage.

## Validation

Backend GitHub Actions covers:

- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `terraform fmt -check -recursive terraform`
- `terraform validate`

The tests use fake LLM clients and make no external model calls. Coverage percentages in the matrix documents are explicitly marked as not yet measured.

## Follow-up

The matrices identify the next priorities: scripted agent-loop scenarios, ADK adapter runtime round trips, existing-tree prompt injection, renderer failures, cancellation semantics, and eval cases for `quality_critique`, `deduplicate_and_merge`, `generate_brief`, and `generate_html_summary`.
