### PR TITLE
Add platform end-to-end smoke tests

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -54,13 +54,51 @@ jobs:
         working-directory: apps/web
         run: bun run build
 
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CI: true
+      E2E_API_BASE_URL: http://127.0.0.1:8080
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        working-directory: apps/web
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run end-to-end tests
+        working-directory: apps/web
+        run: bun run e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report
+          retention-days: 7
+
+      - name: Stop composed services
+        if: always()
+        run: docker compose -f compose.yaml down --volumes --remove-orphans
+
   notify:
-    needs: web
+    needs: [web, e2e]
     if: failure()
     uses: ./.github/workflows/notify-discord.yml
     with:
       status: failure
       workflow_name: Web
-      job_name: web
+      job_name: ${{ needs.web.result == 'failure' && 'web' || 'e2e' }}
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/apps/web/e2e/platform.spec.ts
+++ b/apps/web/e2e/platform.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+
+function localBackendPort(): string {
+  try {
+    return readFileSync(new URL('../../../.env', import.meta.url), 'utf8').match(/^BACKEND_PORT=(\d+)$/m)?.[1] ?? '8080';
+  } catch {
+    return '8080';
+  }
+}
+
+const apiBaseURL = process.env.E2E_API_BASE_URL ?? `http://127.0.0.1:${localBackendPort()}`;
+
+test.describe('platform smoke tests', () => {
+  test('backend liveness endpoint responds from the composed application', async ({ request }) => {
+    await expect
+      .poll(
+        async () => {
+          const response = await request.get(`${apiBaseURL}/health`);
+          return { status: response.status(), body: await response.text() };
+        },
+        { timeout: 60_000 },
+      )
+      .toEqual({ status: 200, body: 'ok' });
+  });
+
+  test('backend readiness endpoint reaches its dependencies', async ({ request }) => {
+    await expect
+      .poll(
+        async () => {
+          const response = await request.get(`${apiBaseURL}/health?ready=1`);
+          return { status: response.status(), body: await response.text() };
+        },
+        { timeout: 60_000 },
+      )
+      .toEqual({ status: 200, body: 'ok' });
+  });
+
+  test('authenticated browser session survives a full page reload', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible();
+
+    await page.reload();
+
+    await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible();
+    await expect(page.getByText('ワークスペース', { exact: true }).first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds Playwright end-to-end coverage for the composed Synthify platform.

### New E2E coverage

- verifies the API liveness endpoint through the real composed backend
- verifies the API readiness endpoint reaches its dependencies
- verifies an authenticated Firebase Emulator browser session survives a full reload

### CI

- adds a dedicated `e2e` job to the Web workflow
- installs Playwright Chromium
- starts the existing frontend/backend/worker Compose stack through Playwright's `webServer`
- uploads the Playwright HTML report on failure
- always tears down composed services and volumes

## Validation

GitHub Actions will run the existing Web checks and the new Playwright E2E job.
