### PR TITLE
chore(eval): close out eval runner gaps (CI paths, docs, variants seam)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - apps/api/**
       - apps/worker/**
+      - apps/eval/**
       - internal/platform/**
       - go.mod
       - go.sum
@@ -16,6 +17,7 @@ on:
     paths:
       - apps/api/**
       - apps/worker/**
+      - apps/eval/**
       - internal/platform/**
       - go.mod
       - go.sum

--- a/apps/eval/cmd/main.go
+++ b/apps/eval/cmd/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	cfg := config.LoadLLM()
 	if !cfg.Enabled() {
-		fmt.Fprintln(os.Stderr, "configure GCP_PROJECT/GOOGLE_CLOUD_PROJECT for Vertex AI, or run on Cloud Run with metadata available")
+		fmt.Fprintln(os.Stderr, "configure GCP_PROJECT/GOOGLE_CLOUD_PROJECT for Vertex AI, set GEMINI_API_KEY/GOOGLE_API_KEY for the Gemini API, or run on Cloud Run with metadata available")
 		os.Exit(2)
 	}
 

--- a/apps/eval/runner/cases_smoke_test.go
+++ b/apps/eval/runner/cases_smoke_test.go
@@ -1,0 +1,83 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/synthify/backend/apps/worker/pkg/worker/domain"
+	"github.com/synthify/backend/apps/worker/pkg/worker/llm"
+)
+
+// chunkHeadingLLM is a prompt-driven fake: it echoes the chunk headings the
+// renderer embedded in the user prompt back as one level-1 tree item each. It
+// takes no case knowledge — whatever titles actually reached the model are the
+// titles it returns.
+//
+// This makes the smoke test a real end-to-end plumbing check of the committed
+// cases WITHOUT a live LLM: YAML parse, fixture path resolution, input schema
+// validation, prompt render (chunks embedded), output schema validation, and
+// the expect.json rules (count_gte / tree_depth_lte / contains_all) all run
+// against the real apps/eval/cases + apps/eval/testdata. It does NOT judge
+// model quality — only that the harness wires together and that each case's
+// expectations are satisfiable from the fixture headings.
+type chunkHeadingLLM struct{}
+
+var chunkLine = regexp.MustCompile(`(?m)^\[\d+\]\s+(.+?)\s*$`)
+
+func (chunkHeadingLLM) GenerateStructured(_ context.Context, req llm.StructuredRequest) (json.RawMessage, llm.Usage, error) {
+	matches := chunkLine.FindAllStringSubmatch(req.UserPrompt, -1)
+	items := make([]domain.GeneratedTreeItem, 0, len(matches))
+	for i, m := range matches {
+		items = append(items, domain.GeneratedTreeItem{
+			LocalID: "item_" + itoa(i+1),
+			Title:   m[1],
+			Level:   1,
+		})
+	}
+	raw, err := json.Marshal(map[string]any{"items": items})
+	return raw, llm.Usage{Model: "fake-chunk-heading", InputTokens: 1, OutputTokens: 1}, err
+}
+
+func (chunkHeadingLLM) GenerateText(context.Context, llm.TextRequest) (string, llm.Usage, error) {
+	return "", llm.Usage{}, nil
+}
+
+func itoa(i int) string {
+	return string(rune('0'+i%10)) // single-digit ids are enough for the fixtures
+}
+
+// TestCommittedCasesPassWithFakeLLM runs every real case in apps/eval/cases
+// through the runner with the prompt-driven fake and asserts all pass. It
+// guards against a case file, fixture, or expect rule drifting into a state the
+// harness cannot even satisfy offline (e.g. a contains_all value no fixture
+// heading matches, a bad JSON path, an unloadable chunks fixture).
+func TestCommittedCasesPassWithFakeLLM(t *testing.T) {
+	casesDir := filepath.Join("..", "cases")
+	files, err := CaseFiles(casesDir)
+	if err != nil {
+		t.Fatalf("CaseFiles(%s): %v", casesDir, err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no committed cases found under %s", casesDir)
+	}
+
+	results, err := Runner{LLM: chunkHeadingLLM{}}.RunCaseFiles(context.Background(), files)
+	if err != nil {
+		t.Fatalf("RunCaseFiles: %v", err)
+	}
+	if len(results) != len(files) {
+		t.Fatalf("expected %d results, got %d", len(files), len(results))
+	}
+	for _, res := range results {
+		if !res.SchemaValid {
+			t.Errorf("case %q: output failed schema validation", res.CaseName)
+		}
+		if !res.Passed {
+			t.Errorf("case %q: not passed (error=%q, output=%s)", res.CaseName, res.Error, res.Output)
+		}
+		t.Logf("case %q: passed=%t schema_valid=%t prompt_source=%s", res.CaseName, res.Passed, res.SchemaValid, res.PromptSource)
+	}
+}

--- a/apps/eval/variants/.gitkeep
+++ b/apps/eval/variants/.gitkeep
@@ -1,0 +1,13 @@
+# apps/eval/variants
+#
+# Handwritten prompt variant template sets. Each variant lives in its own
+# directory and is selected with `--variant {name}`:
+#
+#   apps/eval/variants/{name}/knowledge_tree.system.tmpl
+#   apps/eval/variants/{name}/knowledge_tree.user.tmpl
+#
+# The render input contract is identical to the production templates
+# (apps/worker/pkg/worker/prompts/templates). Variant templates must NOT be
+# baked into the production worker image.
+#
+# Contract: docs/contracts/prompt-variant-eval-contract.md §3.

--- a/docs/contracts/llm-eval-runner-contract.md
+++ b/docs/contracts/llm-eval-runner-contract.md
@@ -56,12 +56,21 @@ input:
   chunks: ../testdata/api_spec_chunks.json
 expect:
   schema_valid: true
-  min_items: 3
-  max_depth: 4
-  must_contain_titles:
-    - "認証"
-    - "エラーハンドリング"
+  json:
+    - path: $.items
+      op: count_gte
+      value: 3
+    - path: $.items
+      op: tree_depth_lte
+      value: 4
+    - path: $.items[*].title
+      op: contains_all
+      value:
+        - "認証"
+        - "エラーハンドリング"
 ```
+
+`expect` は道A（[llm-eval-runner.md](../improvements/llm-eval-runner.md)）で `schema_valid` と `json` rule に統一済み。旧 `min_items` / `max_depth` / `must_contain_titles` は廃止し、それぞれ `count_gte` / `tree_depth_lte` / `contains_all`（`$.items[*].title` に対する部分一致）で表現する。JSON path は軽量 subset（`$.x`, `$.x[*].y`, `$.x[i]`）のみを扱う。
 
 `input.chunks` は case file の directory からの相対 path、または絶対 path とする。fixture は `[]domain.Chunk` JSON で固定する。PDF や raw document からの抽出は eval 対象に含めない。
 
@@ -71,20 +80,21 @@ JSON report は `[]Result` を stdout に出す。`--out` 指定時は同じ byt
 
 主な field:
 
+道A 移行で Result は tool 非依存の output JSON に統一済み。tree 固有 field（`item_count` / `max_depth` / `missing_titles` / `items`）は削除された（[prompt-variant-eval-contract.md](prompt-variant-eval-contract.md) §6）。
+
 | field | 内容 |
 | :--- | :--- |
 | `case_name` / `tool` | 実行 case の識別子 |
-| `passed` | schema/rule/error を総合した合否 |
-| `schema_valid` | LLM 出力が `GeneratedTreeItem` として parse できたか |
-| `item_count` / `max_depth` | 生成 item 数と最大階層 |
-| `missing_titles` | `expect.must_contain_titles` の未達項目 |
+| `passed` | `schema_valid` かつ `expect.json` の全 rule pass、かつ tool error なしの総合合否 |
+| `schema_valid` | tool の宣言 IOSchema に output JSON が適合したか（道A の共通最低判定） |
+| `output` | tool が返した output JSON そのまま（tool 非依存）。JSON report のみ実質レビュー対象 |
+| `prompt_source` | `production` または `variant:{name}` |
 | `duration_ms` | LLM call を含む case 実行時間 |
 | `model` / `input_tokens` / `output_tokens` | LLM provider の usage |
-| `items` | 生成された `[]domain.GeneratedTreeItem`。JSON report のみ実質レビュー対象 |
-| `error` | LLM call / parse error |
+| `error` | tool-level error（LLM call / parse error / no items）。空なら成功 |
 | `failed_input` | fail 時のみ。document_id、instruction、chunks path、chunks 本体 |
 
-`content` 内の HTML は可読性のため `<`, `>`, `&` を Unicode escape しない。
+`output` 内の HTML は可読性のため `<`, `>`, `&` を Unicode escape しない。
 
 ## 5. Cloud Run Job / Scheduler 契約
 


### PR DESCRIPTION
## 概要

eval 基盤（`apps/eval`）は実装・インフラ・テストがほぼ完成しているが、道A 移行後に取り残された周辺の抜けが残っていた。認証（GCP）不要で潰せるものをまとめて片付ける。

## 変更内容

- **backend CI の paths 漏れ**: `.github/workflows/backend.yml` の `pull_request` / `push` トリガに `apps/eval/**` を追加。これまで **apps/eval だけを触った PR では `go vet/build/test` が一切走らなかった**。
- **CLI エラーメッセージ**: LLM 未設定時のメッセージが `GCP_PROJECT` のみ案内していたが、実際は `GEMINI_API_KEY` / `GOOGLE_API_KEY`（Cloud Run Job の経路）でも `Enabled()` は true になる。両方を案内するよう修正。
- **runner contract のドキュメント乖離**: `docs/contracts/llm-eval-runner-contract.md` の §3（case 形式）と §4（report field）が道A 移行前の旧仕様のままだった。旧 `min_items` / `max_depth` / `must_contain_titles`・`item_count` / `missing_titles` / `items` を、実装が使う `expect.json`（`count_gte` / `tree_depth_lte` / `contains_all`）＋ tool 非依存の `output` payload に更新。
- **variants seam**: `apps/eval/variants/`（`.gitkeep`）を追加し、`--variant` のディレクトリレイアウト（prompt-variant-eval-contract §3）を明記。

## 検証

- `go build ./apps/eval/...` ✓
- `go test ./apps/eval/...` ✓（artifact / cmd / report / runner 全パス）

## このPRに含めていないもの（別途対応が必要）

- **実 LLM での実行検証**: 3 ケースの `expect` 閾値はまだ実 Gemini/Vertex で一度も緑を確認していない。GCP 認証が要るためこの PR の範囲外。手元で `go run ./apps/eval/cmd --cases apps/eval/cases --format table`（または `gcloud run jobs execute synthify-eval-stage`）を 1 回走らせて確認・閾値調整が必要。
- nightly eval 失敗時の通知（Cloud Logging 止まり）。契約 §7 ではスコープ外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019FVcsSAvUR2iZ8v8u8616Q)_