### PR TITLE
Add CI/CD runtime visibility reports

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -26,6 +26,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Start CI/CD sensor
+        uses: cicd-sensor/cicd-sensor-action@v0.0.43
+        with:
+          enable-html-report: true
+          enable-attestation-artifact: false
+          enable-debug: false
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
@@ -45,6 +52,13 @@ jobs:
   terraform:
     runs-on: ubuntu-latest
     steps:
+      - name: Start CI/CD sensor
+        uses: cicd-sensor/cicd-sensor-action@v0.0.43
+        with:
+          enable-html-report: true
+          enable-attestation-artifact: false
+          enable-debug: false
+
       - uses: actions/checkout@v4
 
       - uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -23,6 +23,13 @@ jobs:
       STRIPE_SECRET_KEY: sk_test_e2e_dummy
       STRIPE_PRO_PRICE_ID_JPY: price_e2e_dummy_jpy
     steps:
+      - name: Start CI/CD sensor
+        uses: cicd-sensor/cicd-sensor-action@v0.0.43
+        with:
+          enable-html-report: true
+          enable-attestation-artifact: false
+          enable-debug: false
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive


### PR DESCRIPTION
## What changed

- Add `cicd-sensor/cicd-sensor-action@v0.0.43` as the first step in the backend build, Terraform, and Web CI jobs.
- Enable the HTML runtime report artifact.
- Disable attestation and debug artifacts for the initial rollout.
- Do not add any deny or blocking behavior.

## Why

This provides visibility into processes and runtime activity inside GitHub Actions without changing pass/fail behavior. The generated `cicd-sensor-report` artifact can be reviewed from each workflow run.

## Impact

CI jobs should continue to behave as before, with an additional HTML report artifact uploaded after each instrumented job. This is intentionally limited to regular CI workflows before considering deployment workflows.

## Validation

- Reviewed workflow YAML structure.
- Sensor step is placed before checkout so setup, dependency installation, build, test, and Terraform activity are observable.