### PR TITLE
feat(monitor): host on Cloud Run behind app-layer admin auth

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -65,6 +65,7 @@ jobs:
           echo "api_image=${REGISTRY}/api:${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
           echo "worker_image=${REGISTRY}/worker:${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
           echo "eval_image=${REGISTRY}/eval:${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+          echo "monitor_image=${REGISTRY}/monitor:${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
 
       - name: Generate readiness smoke key
         run: |
@@ -109,7 +110,7 @@ jobs:
       - name: Verify all secrets have a version
         run: |
           missing=()
-          for s in database-dsn stripe-secret-key \
+          for s in database-dsn monitor-database-dsn stripe-secret-key \
                    stripe-webhook-secret new-relic-license-key internal-worker-token \
                    gemini-api-key; do
             name="synthify-${s}"
@@ -165,7 +166,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Build and push all three images in parallel. Each uses a GHA-scoped
+      # Build and push all four images in parallel. Each uses a GHA-scoped
       # BuildKit cache keyed by image name + environment so pushes to stage
       # and prod never share cache entries.
       - name: Build and push images (parallel)
@@ -195,6 +196,23 @@ jobs:
             -t "${{ steps.registry.outputs.eval_image }}" \
             -t "${{ steps.registry.outputs.registry }}/eval:latest" \
             -f apps/eval/Dockerfile --push . &
+          pids+=($!)
+
+          # Monitor is a Next.js app: NEXT_PUBLIC_* are baked into the client
+          # bundle at build time, so they are passed as build args (not runtime
+          # env). Server-side secrets (MONITOR_DATABASE_URL) stay in Cloud Run.
+          docker buildx build \
+            --cache-from "type=gha,scope=monitor-${ENVIRONMENT}" \
+            --cache-to   "type=gha,scope=monitor-${ENVIRONMENT},mode=max" \
+            --build-arg "NEXT_PUBLIC_FIREBASE_API_KEY=${{ vars.NEXT_PUBLIC_FIREBASE_API_KEY }}" \
+            --build-arg "NEXT_PUBLIC_FIREBASE_PROJECT_ID=${{ vars.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}" \
+            --build-arg "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ vars.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}" \
+            --build-arg "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=${{ vars.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET }}" \
+            --build-arg "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=${{ vars.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID }}" \
+            --build-arg "NEXT_PUBLIC_FIREBASE_APP_ID=${{ vars.NEXT_PUBLIC_FIREBASE_APP_ID }}" \
+            -t "${{ steps.registry.outputs.monitor_image }}" \
+            -t "${{ steps.registry.outputs.registry }}/monitor:latest" \
+            -f apps/monitor/ui/Dockerfile --push . &
           pids+=($!)
 
           failed=0
@@ -228,6 +246,7 @@ jobs:
             -var="api_image=${{ steps.registry.outputs.api_image }}"
             -var="worker_image=${{ steps.registry.outputs.worker_image }}"
             -var="eval_image=${{ steps.registry.outputs.eval_image }}"
+            -var="monitor_image=${{ steps.registry.outputs.monitor_image }}"
             -var="readiness_api_key=${READINESS_API_KEY}"
             -var="readiness_monitor_key=${READINESS_MONITOR_KEY}"
             -var="stripe_pro_price_id_jpy=${STRIPE_PRO_PRICE_ID_JPY}"
@@ -262,6 +281,7 @@ jobs:
             -var="api_image=${{ steps.registry.outputs.api_image }}"
             -var="worker_image=${{ steps.registry.outputs.worker_image }}"
             -var="eval_image=${{ steps.registry.outputs.eval_image }}"
+            -var="monitor_image=${{ steps.registry.outputs.monitor_image }}"
             -var="api_base_url=${API_URI}"
             -var="readiness_api_key=${READINESS_API_KEY}"
             -var="readiness_monitor_key=${READINESS_MONITOR_KEY}"

--- a/apps/monitor/README.md
+++ b/apps/monitor/README.md
@@ -69,6 +69,10 @@ api / worker / eval と同じ `deploy-backend.yml` パイプラインで Cloud R
 - **公開範囲**: `ingress = all` の公開 Cloud Run。ネットワーク層では開き、
   アプリ層の `requireAdmin`（Firebase ID トークン + `SYNTHIFY_ADMIN_USER_EMAILS`）
   で認可する。
+- **URL**: カスタムドメインを Cloud Run domain mapping で割り当てる。ドメインは
+  各環境の tfvars の `monitor_domain` で注入する（`web_base_url` と同じ流儀）:
+  prod = `monitor.synthify.keyhole.work` / stage = `stage.monitor.synthify.keyhole.work`。
+  空にすると mapping を作らず run.app URL のまま。
 - **terraform**: `terraform/services/monitor`。SA・`monitor-database-dsn`
   シークレット・IAM は `terraform/services/platform` に定義。
 
@@ -83,3 +87,8 @@ api / worker / eval と同じ `deploy-backend.yml` パイプラインで Cloud R
    （frontend デプロイと共通なので既存の可能性が高い）。
 4. `SYNTHIFY_ADMIN_USER_EMAILS`（tfvars の `admin_user_emails`）が api と
    同じ値になっていることを確認する。
+5. **カスタムドメイン**: (a) 対象ドメインを GCP プロジェクトで所有権確認
+   （domain verification）し、(b) apply 後に `terraform output monitor_dns_records`
+   が返す DNS レコードを keyhole.work ゾーンに登録する。domain mapping は
+   リージョン制限があるため、デプロイリージョンが非対応の場合は
+   `monitor_domain` を空にして external HTTPS LB（serverless NEG）で前段する。

--- a/apps/monitor/README.md
+++ b/apps/monitor/README.md
@@ -57,3 +57,29 @@ BI 用の view と read-only ロールへの GRANT は以下のマイグレー�
 
 リポジトリ全体の `compose.yaml` で `monitor` サービスとして起動する
 (`bun run dev`, port 5174)。詳細はルートの `README.md` / `Makefile` を参照。
+
+## デプロイ (Cloud Run)
+
+api / worker / eval と同じ `deploy-backend.yml` パイプラインで Cloud Run
+サービス `synthify-monitor-<env>` としてデプロイされる。
+
+- **イメージ**: `apps/monitor/ui/Dockerfile`（monorepo コンテキスト・Next.js
+  standalone）。`NEXT_PUBLIC_FIREBASE_*` はクライアントバンドルに焼き込まれる
+  ため **ビルド時の build-arg** で渡す（GitHub Environment vars を利用）。
+- **公開範囲**: `ingress = all` の公開 Cloud Run。ネットワーク層では開き、
+  アプリ層の `requireAdmin`（Firebase ID トークン + `SYNTHIFY_ADMIN_USER_EMAILS`）
+  で認可する。
+- **terraform**: `terraform/services/monitor`。SA・`monitor-database-dsn`
+  シークレット・IAM は `terraform/services/platform` に定義。
+
+### 初回デプロイ時の手動作業
+
+1. DB マイグレーション適用後、`monitor` ロールにパスワードを設定する
+   （`0014_monitor_role.up.sql` はパスワードなしで `CREATE ROLE`）:
+   `ALTER ROLE monitor WITH PASSWORD '…';`
+2. read-only DSN をシークレットに登録する:
+   `printf '<dsn>' | gcloud secrets versions add synthify-monitor-database-dsn --project <project> --data-file=-`
+3. `NEXT_PUBLIC_FIREBASE_*` の GitHub Environment vars を設定する
+   （frontend デプロイと共通なので既存の可能性が高い）。
+4. `SYNTHIFY_ADMIN_USER_EMAILS`（tfvars の `admin_user_emails`）が api と
+   同じ値になっていることを確認する。

--- a/apps/monitor/ui/Dockerfile
+++ b/apps/monitor/ui/Dockerfile
@@ -1,19 +1,51 @@
+# syntax=docker/dockerfile:1
+
+# monorepo (bun workspaces) 上の Next.js standalone ビルド。
+# ビルドコンテキストはリポジトリルート:  docker build -f apps/monitor/ui/Dockerfile .
+
+# ---- deps: lockfile + 全ワークスペースの package.json だけで依存解決 ----
 FROM oven/bun:1.3.13-alpine AS deps
-WORKDIR /app
-COPY package.json bun.lock* ./
+WORKDIR /repo
+COPY package.json bun.lock ./
+COPY apps/web/package.json apps/web/package.json
+COPY apps/monitor/ui/package.json apps/monitor/ui/package.json
 RUN bun install --frozen-lockfile
 
+# ---- builder: ソースを載せて monitor を standalone ビルド ----
 FROM oven/bun:1.3.13-alpine AS builder
-WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
+WORKDIR /repo
+COPY --from=deps /repo/node_modules ./node_modules
 COPY . .
+
+# NEXT_PUBLIC_* はクライアントバンドルへビルド時に焼き込まれるので build-arg で渡す。
+ARG NEXT_PUBLIC_FIREBASE_API_KEY
+ARG NEXT_PUBLIC_FIREBASE_PROJECT_ID
+ARG NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+ARG NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+ARG NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+ARG NEXT_PUBLIC_FIREBASE_APP_ID
+ENV NEXT_PUBLIC_FIREBASE_API_KEY=$NEXT_PUBLIC_FIREBASE_API_KEY \
+    NEXT_PUBLIC_FIREBASE_PROJECT_ID=$NEXT_PUBLIC_FIREBASE_PROJECT_ID \
+    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=$NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN \
+    NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=$NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET \
+    NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=$NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID \
+    NEXT_PUBLIC_FIREBASE_APP_ID=$NEXT_PUBLIC_FIREBASE_APP_ID \
+    NEXT_TELEMETRY_DISABLED=1
+
+WORKDIR /repo/apps/monitor/ui
 RUN bun run build
 
+# ---- runner: standalone 出力のみを載せた薄いイメージ ----
 FROM oven/bun:1.3.13-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/public* ./public/
-EXPOSE 5174
-CMD ["bun", "server.js"]
+ENV HOSTNAME=0.0.0.0
+# PORT は Cloud Run が注入する (Next standalone server は process.env.PORT を読む)。
+
+# outputFileTracingRoot=リポジトリルートなので standalone はリポジトリ構造を保持する:
+#   .next/standalone/apps/monitor/ui/server.js  +  .next/standalone/node_modules
+COPY --from=builder /repo/apps/monitor/ui/.next/standalone ./
+COPY --from=builder /repo/apps/monitor/ui/.next/static ./apps/monitor/ui/.next/static
+
+EXPOSE 8080
+CMD ["bun", "apps/monitor/ui/server.js"]

--- a/apps/monitor/ui/next.config.ts
+++ b/apps/monitor/ui/next.config.ts
@@ -11,6 +11,9 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: path.join(__dirname, '..', '..', '..'),
   },
+  // monorepo (bun workspaces) なので standalone のトレース基点をリポジトリルート
+  // に固定する。これで出力は .next/standalone/apps/monitor/ui/server.js になる。
+  outputFileTracingRoot: path.join(__dirname, '..', '..', '..'),
   output: 'standalone',
   images: { unoptimized: true },
 };

--- a/terraform/environments/main.tf
+++ b/terraform/environments/main.tf
@@ -115,6 +115,7 @@ module "monitor" {
   firebase_project_id   = local.firebase_project_id
   admin_user_emails     = var.admin_user_emails
   deletion_protection   = local.deletion_protection
+  domain                = var.monitor_domain
 }
 
 module "monitoring" {

--- a/terraform/environments/main.tf
+++ b/terraform/environments/main.tf
@@ -103,6 +103,20 @@ module "api" {
   deletion_protection               = local.deletion_protection
 }
 
+module "monitor" {
+  source = "../services/monitor"
+
+  project_id            = var.project_id
+  region                = var.region
+  name                  = "synthify-monitor-${var.environment}"
+  image                 = var.monitor_image
+  service_account_email = module.bootstrap.monitor_service_account_email
+  secret_ids            = module.bootstrap.secret_ids
+  firebase_project_id   = local.firebase_project_id
+  admin_user_emails     = var.admin_user_emails
+  deletion_protection   = local.deletion_protection
+}
+
 module "monitoring" {
   source = "../services/monitoring"
 

--- a/terraform/environments/outputs.tf
+++ b/terraform/environments/outputs.tf
@@ -6,6 +6,10 @@ output "worker_uri" {
   value = module.worker.uri
 }
 
+output "monitor_uri" {
+  value = module.monitor.uri
+}
+
 output "eval_job_name" {
   value = module.eval.name
 }

--- a/terraform/environments/outputs.tf
+++ b/terraform/environments/outputs.tf
@@ -10,6 +10,15 @@ output "monitor_uri" {
   value = module.monitor.uri
 }
 
+output "monitor_domain" {
+  value = module.monitor.domain
+}
+
+# DNS records to add to the keyhole.work zone for the monitor custom domain.
+output "monitor_dns_records" {
+  value = module.monitor.dns_records
+}
+
 output "eval_job_name" {
   value = module.eval.name
 }

--- a/terraform/environments/variables.tf
+++ b/terraform/environments/variables.tf
@@ -29,6 +29,12 @@ variable "eval_image" {
   default     = ""
 }
 
+variable "monitor_image" {
+  description = "Monitor dashboard container image. Passed by CD via -var after build&push; not stored in tfvars."
+  type        = string
+  default     = ""
+}
+
 # Public web origin (no trailing slash), e.g. https://stage.synthify.keyhole.work.
 # CORS + billing redirect URLs are derived from this in locals.tf.
 variable "web_base_url" {

--- a/terraform/environments/variables.tf
+++ b/terraform/environments/variables.tf
@@ -35,6 +35,12 @@ variable "monitor_image" {
   default     = ""
 }
 
+variable "monitor_domain" {
+  description = "Custom domain (bare hostname, no scheme) for the monitor dashboard, set per-env in tfvars. Empty => no domain mapping (use the run.app URL)."
+  type        = string
+  default     = ""
+}
+
 # Public web origin (no trailing slash), e.g. https://stage.synthify.keyhole.work.
 # CORS + billing redirect URLs are derived from this in locals.tf.
 variable "web_base_url" {

--- a/terraform/services/bootstrap/main.tf
+++ b/terraform/services/bootstrap/main.tf
@@ -41,6 +41,7 @@ locals {
     eval           = module.platform.eval_service_account_email
     eval_scheduler = module.platform.eval_scheduler_service_account_email
     api            = module.platform.api_service_account_email
+    monitor        = module.platform.monitor_service_account_email
   }
 }
 

--- a/terraform/services/bootstrap/outputs.tf
+++ b/terraform/services/bootstrap/outputs.tf
@@ -25,6 +25,10 @@ output "eval_scheduler_service_account_email" {
   value = module.platform.eval_scheduler_service_account_email
 }
 
+output "monitor_service_account_email" {
+  value = module.platform.monitor_service_account_email
+}
+
 output "pipeline_queue_name" {
   value = module.platform.pipeline_queue_name
 }

--- a/terraform/services/monitor/main.tf
+++ b/terraform/services/monitor/main.tf
@@ -1,0 +1,41 @@
+# The monitor dashboard (Next.js BFF). It reads Postgres directly through a
+# read-only `monitor` role and serves the operations dashboards. Access is
+# gated at the app layer (requireAdmin: Firebase ID token + admin allowlist),
+# so the network ingress is public like the API.
+module "service" {
+  source = "../../modules/cloud_run_service"
+
+  project_id            = var.project_id
+  region                = var.region
+  name                  = var.name
+  image                 = var.image
+  service_account_email = var.service_account_email
+
+  # Public ingress; the app enforces admin-only access via requireAdmin. A
+  # signed-in non-admin (or anonymous) request is rejected with 401/403 by
+  # every /api/* route, and the UI shows a sign-in gate.
+  allow_unauthenticated = true
+  ingress               = "INGRESS_TRAFFIC_ALL"
+  deletion_protection   = var.deletion_protection
+
+  # PORT is a Cloud Run reserved env var, injected from the container port
+  # (default 8080). The Next.js standalone server reads PORT/HOSTNAME.
+  env_vars = {
+    NODE_ENV = "production"
+    HOSTNAME = "0.0.0.0"
+    # Firebase ID token verification (project id + Google public certs; no
+    # service-account key needed, same as the API's authenticator).
+    FIREBASE_PROJECT_ID = var.firebase_project_id
+    # Admin allowlist shared with the API. Empty => fail-closed (all 403).
+    SYNTHIFY_ADMIN_USER_EMAILS = var.admin_user_emails
+  }
+
+  # Read-only DSN for the `monitor` Postgres role. Distinct from the api/worker
+  # database-dsn secret so the dashboard can only SELECT.
+  secret_env_vars = [
+    {
+      name   = "MONITOR_DATABASE_URL"
+      secret = var.secret_ids["monitor-database-dsn"]
+    },
+  ]
+}

--- a/terraform/services/monitor/main.tf
+++ b/terraform/services/monitor/main.tf
@@ -39,3 +39,24 @@ module "service" {
     },
   ]
 }
+
+# Optional custom domain (e.g. monitor.synthify.keyhole.work). Prerequisites,
+# done out-of-band: (1) verify the domain in this GCP project, and (2) add the
+# DNS records Cloud Run returns (see the monitor_dns_records output) to the
+# keyhole.work zone. Region availability for domain mappings is limited; if the
+# deploy region is unsupported, front the service with a global external HTTPS
+# load balancer (serverless NEG) instead and leave var.domain empty.
+resource "google_cloud_run_domain_mapping" "this" {
+  count    = var.domain == "" ? 0 : 1
+  project  = var.project_id
+  location = var.region
+  name     = var.domain
+
+  metadata {
+    namespace = var.project_id
+  }
+
+  spec {
+    route_name = module.service.name
+  }
+}

--- a/terraform/services/monitor/outputs.tf
+++ b/terraform/services/monitor/outputs.tf
@@ -1,0 +1,7 @@
+output "uri" {
+  value = module.service.uri
+}
+
+output "name" {
+  value = module.service.name
+}

--- a/terraform/services/monitor/outputs.tf
+++ b/terraform/services/monitor/outputs.tf
@@ -5,3 +5,14 @@ output "uri" {
 output "name" {
   value = module.service.name
 }
+
+output "domain" {
+  description = "Custom domain mapped to the service, or empty if none."
+  value       = var.domain
+}
+
+# DNS records Cloud Run expects for the custom domain. Add these to the
+# keyhole.work zone. Empty when no domain is mapped.
+output "dns_records" {
+  value = var.domain == "" ? [] : google_cloud_run_domain_mapping.this[0].status[0].resource_records
+}

--- a/terraform/services/monitor/variables.tf
+++ b/terraform/services/monitor/variables.tf
@@ -1,0 +1,40 @@
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "image" {
+  type = string
+}
+
+variable "service_account_email" {
+  type = string
+}
+
+variable "secret_ids" {
+  description = "platform module output: map of secret key -> secret_id"
+  type        = map(string)
+}
+
+variable "firebase_project_id" {
+  type = string
+}
+
+variable "admin_user_emails" {
+  description = "Comma-separated admin allowlist. Only these emails may reach the dashboards/jobs APIs. Empty => fail-closed (all 403)."
+  type        = string
+  default     = ""
+}
+
+variable "deletion_protection" {
+  description = "Cloud Run delete guard. false in non-prod so a tainted service can be replaced."
+  type        = bool
+  default     = true
+}

--- a/terraform/services/monitor/variables.tf
+++ b/terraform/services/monitor/variables.tf
@@ -38,3 +38,9 @@ variable "deletion_protection" {
   type        = bool
   default     = true
 }
+
+variable "domain" {
+  description = "Custom domain to map to the service (e.g. monitor.synthify.keyhole.work). Empty => no mapping (use the run.app URL). The domain must be verified in the project and its DNS records pointed at Cloud Run out-of-band."
+  type        = string
+  default     = ""
+}

--- a/terraform/services/platform/main.tf
+++ b/terraform/services/platform/main.tf
@@ -60,6 +60,16 @@ module "eval_scheduler_service_account" {
   depends_on = [google_project_service.required]
 }
 
+module "monitor_service_account" {
+  source = "../../modules/service_account"
+
+  project_id   = var.project_id
+  account_id   = "synthify-monitor-${var.environment}"
+  display_name = "Synthify Monitor (${var.environment})"
+
+  depends_on = [google_project_service.required]
+}
+
 module "pipeline_queue" {
   source = "../../modules/cloud_tasks_queue"
 
@@ -107,7 +117,18 @@ locals {
     "gemini-api-key",
   ])
 
-  all_secrets = toset(concat(tolist(local.api_secrets), tolist(local.worker_secrets), tolist(local.eval_secrets)))
+  # monitor は read-only の monitor ロールを指す DSN のみ (api/worker とは別の
+  # 資格情報)。MONITOR_DATABASE_URL としてマウントする。
+  monitor_secrets = toset([
+    "monitor-database-dsn",
+  ])
+
+  all_secrets = toset(concat(
+    tolist(local.api_secrets),
+    tolist(local.worker_secrets),
+    tolist(local.eval_secrets),
+    tolist(local.monitor_secrets),
+  ))
 }
 
 resource "google_secret_manager_secret" "secrets" {
@@ -141,6 +162,13 @@ resource "google_secret_manager_secret_iam_member" "eval_accessor" {
   secret_id = google_secret_manager_secret.secrets[each.value].id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${module.eval_service_account.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "monitor_accessor" {
+  for_each  = local.monitor_secrets
+  secret_id = google_secret_manager_secret.secrets[each.value].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${module.monitor_service_account.email}"
 }
 
 resource "google_storage_bucket_iam_member" "eval_artifact_writer" {

--- a/terraform/services/platform/outputs.tf
+++ b/terraform/services/platform/outputs.tf
@@ -22,6 +22,10 @@ output "eval_scheduler_service_account_email" {
   value = module.eval_scheduler_service_account.email
 }
 
+output "monitor_service_account_email" {
+  value = module.monitor_service_account.email
+}
+
 output "pipeline_queue_name" {
   value = module.pipeline_queue.name
 }

--- a/terraform/tfvars/prod.tfvars
+++ b/terraform/tfvars/prod.tfvars
@@ -3,6 +3,9 @@ region       = "asia-northeast1"
 environment  = "prod"
 web_base_url = "https://synthify.keyhole.work"
 
+# monitor ダッシュボードのカスタムドメイン (scheme なしのホスト名)。
+monitor_domain = "monitor.synthify.keyhole.work"
+
 # CI/WIF SA that runs terraform apply (GCP_WIF_SA_EMAIL). Needs actAs on
 # the api/worker runtime SAs to attach them to Cloud Run.
 deployer_principal = "serviceAccount:github-deploy@synthify-491705.iam.gserviceaccount.com"

--- a/terraform/tfvars/stage.tfvars
+++ b/terraform/tfvars/stage.tfvars
@@ -3,6 +3,9 @@ region       = "asia-northeast1"
 environment  = "stage"
 web_base_url = "https://stage.synthify.keyhole.work"
 
+# monitor ダッシュボードのカスタムドメイン (scheme なしのホスト名)。
+monitor_domain = "stage.monitor.synthify.keyhole.work"
+
 # Lock stage to a single account. CD overrides this with the GitHub
 # Environment variable ALLOWED_USER_EMAILS when set; this value is the
 # fallback so a manual `make infra-stage-up` is locked down too.


### PR DESCRIPTION
## Summary

monitor ダッシュボードを既存の `deploy-backend` パイプラインに載せ、**公開 Cloud Run サービス** `synthify-monitor-<env>` としてデプロイできるようにする。ネットワーク層は公開し、**アプリ層の `requireAdmin`**（Firebase ID トークン + `SYNTHIFY_ADMIN_USER_EMAILS`）で認可する。

> ⚠️ **スタック PR**: base は #13（`claude/monitor-status-gaps-7rpele`）。公開ホスティングには #13 の admin 認証が前提のため、そこに積んでいます。**#13 をマージ後、この PR の base を `main` に切り替え（rebase）**してください。diff は hosting 差分のみになるようにしています。

## URL / カスタムドメイン

Cloud Run domain mapping で以下を割り当て（`var.monitor_domain` で上書き可）:

- prod: `monitor.synthify.keyhole.work`
- stage: `stage.monitor.synthify.keyhole.work`

min instance = 0（scale-to-zero）なので**アイドル時は無料**、pay-per-use。

## Terraform

- **platform**: monitor 用 SA、`monitor-database-dsn` シークレット + アクセサ IAM、outputs。
- **bootstrap**: monitor SA を re-export、deployer の actAs 追加。
- **新 `services/monitor` モジュール**: 公開 ingress の Cloud Run、`MONITOR_DATABASE_URL`（secret）+ 認証 env、**optional な domain mapping**（count-gated）と `dns_records` 出力。
- **environments**: `module.monitor`、`monitor_image` / `monitor_domain` 変数、`monitor_uri` / `monitor_domain` / `monitor_dns_records` 出力、per-env のドメイン導出 local。

## CI (`deploy-backend.yml`)

- `monitor_image` 解決、シークレット事前チェックに `monitor-database-dsn` 追加、`NEXT_PUBLIC_FIREBASE_*` を build-arg で 4つ目のイメージを build/push、apply 2パスに `-var monitor_image`。

## App

- Dockerfile を monorepo 用に書き直し（Next standalone）、`outputFileTracingRoot` 固定、README にデプロイ手順。

## 検証状況

- ✅ `terraform fmt -recursive -check` パス、参照 locals/vars/outputs の存在も確認。
- ⚠️ **サンドボックスでは `terraform validate` と `docker build` を実行不可**（`registry.terraform.io` と Docker Hub CDN が egress ポリシーで 403）。実ビルド/plan は **CI が検証点**。

## 初回デプロイ時の手動作業

1. `monitor` ロールにパスワード設定（`ALTER ROLE monitor WITH PASSWORD '…';`）
2. read-only DSN を `synthify-monitor-database-dsn` に登録
3. `NEXT_PUBLIC_FIREBASE_*` の GitHub Environment vars 設定
4. `admin_user_emails`（tfvars）が api と同値か確認
5. **カスタムドメイン**: ドメイン所有権確認 + `terraform output monitor_dns_records` の DNS レコードを keyhole.work ゾーンに登録（domain mapping 非対応リージョンなら `monitor_domain` を空にして LB 前段）

🤖 Generated with [Claude Code](https://claude.com/claude-code)