### PR TITLE
feat(qa): post-deploy visual QA for stage frontend (Phase 1)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -30,6 +30,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    outputs:
+      frontend_url: ${{ steps.resolve.outputs.frontend_url }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,6 +91,7 @@ jobs:
             | tee /tmp/firebase-deploy.json
 
       - name: Resolve Firebase Hosting URL
+        id: resolve
         run: |
           FRONTEND_URL="$(
             jq -r '
@@ -106,10 +109,62 @@ jobs:
             FRONTEND_URL="https://${{ vars.GCP_PROJECT_ID }}.web.app"
           fi
           echo "FRONTEND_URL=${FRONTEND_URL}" >> "$GITHUB_ENV"
+          echo "frontend_url=${FRONTEND_URL}" >> "$GITHUB_OUTPUT"
           echo "Resolved Firebase Hosting URL: ${FRONTEND_URL}"
 
       - name: Smoke test Frontend
         run: scripts/smoke-test.sh frontend
+
+  # Post-deploy visual QA (Phase 1): unauthenticated liveness + landing visual
+  # regression against the just-deployed stage site. Reduces manual QA by
+  # catching blank pages, JS crashes, and unintended UI drift automatically.
+  # Gated to stage for now; enable prod once baselines are proven stable.
+  visual-qa:
+    needs: deploy
+    if: ${{ success() && (github.event.inputs.environment || github.ref_name) == 'stage' }}
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run visual QA against deployed stage
+        working-directory: apps/web
+        env:
+          E2E_BASE_URL: ${{ needs.deploy.outputs.frontend_url }}
+        run: bun run e2e:visual
+
+      # On failure, upload both the diff report and any freshly-captured
+      # baselines so a human can either triage the regression or commit new
+      # baselines (see docs/visual-qa.md).
+      - name: Upload visual QA report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-qa-report
+          path: |
+            apps/web/playwright-report
+            apps/web/test-results
+            apps/web/e2e/__screenshots__
+
+      - name: Notify Discord on visual regression
+        if: failure()
+        env:
+          DISCORD_ALERT_WEBHOOK_URL: ${{ secrets.DISCORD_ALERT_WEBHOOK_URL }}
+          ENVIRONMENT: ${{ github.event.inputs.environment || github.ref_name }}
+          FRONTEND_URL: ${{ needs.deploy.outputs.frontend_url }}
+        run: node scripts/notify-visual-diff.mjs
 
   notify:
     needs: deploy

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -121,9 +121,9 @@ jobs:
   # Gated to stage for now; enable prod once baselines are proven stable.
   visual-qa:
     needs: deploy
-    if: ${{ success() && (github.event.inputs.environment || github.ref_name) == 'stage' }}
+    if: ${{ success() && github.ref_name == 'stage' }}
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment || github.ref_name }}
+    environment: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -162,7 +162,7 @@ jobs:
         if: failure()
         env:
           DISCORD_ALERT_WEBHOOK_URL: ${{ secrets.DISCORD_ALERT_WEBHOOK_URL }}
-          ENVIRONMENT: ${{ github.event.inputs.environment || github.ref_name }}
+          ENVIRONMENT: ${{ github.ref_name }}
           FRONTEND_URL: ${{ needs.deploy.outputs.frontend_url }}
         run: node scripts/notify-visual-diff.mjs
 

--- a/apps/web/e2e/deploy-smoke.visual.ts
+++ b/apps/web/e2e/deploy-smoke.visual.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+// Post-deploy visual QA against a live environment (stage/prod). These specs
+// run in the dedicated `visual` Playwright project, which points at
+// E2E_BASE_URL and does NOT authenticate — Phase 1 covers only the
+// unauthenticated surface. Authenticated screens (which need a seeded stage QA
+// account) are Phase 2. Kept separate from the emulator-backed e2e specs so a
+// broken deploy can fail loudly without depending on the local compose stack.
+
+// The landing route mounts the paper-in-paper canvas, whose nodes animate into
+// place. Wait for the unauthenticated login CTA to settle before asserting or
+// snapshotting so we compare a stable frame, not a mid-transition one.
+async function gotoSettledLanding(page: import('@playwright/test').Page) {
+  await page.goto('/', { waitUntil: 'networkidle' });
+  await expect(page.getByRole('button', { name: 'Google でログイン' })).toBeVisible();
+  // Let the 0.32s frame transitions finish; `animations: 'disabled'` freezes
+  // them for the snapshot, but the liveness assertions run before that hook.
+  await page.waitForTimeout(500);
+}
+
+test.describe('deploy smoke (unauthenticated)', () => {
+  // A — liveness: the deploy actually serves a working app, not a blank page
+  // or a JS-crashed shell that curl-based smoke tests happily report as 200.
+  test('@smoke landing renders without runtime errors', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    const pageErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    const response = await page.goto('/', { waitUntil: 'domcontentloaded' });
+    expect(response?.ok(), `landing responded ${response?.status()}`).toBeTruthy();
+
+    // Chrome (brand header) and the unauthenticated CTA must both mount.
+    await expect(page.getByText('Synthify', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Google でログイン' })).toBeVisible();
+
+    expect(pageErrors, 'uncaught page errors').toEqual([]);
+    expect(consoleErrors, 'console errors').toEqual([]);
+  });
+
+  // B — visual regression: compare the settled landing against the committed
+  // baseline. `animations: 'disabled'` (configured project-wide) freezes the
+  // paper-in-paper frame transitions so the diff is deterministic. If a live
+  // environment surfaces a genuinely non-deterministic region (e.g. a demo
+  // document image that varies), mask it here, e.g.
+  //   mask: [page.getByRole('img', { name: /demo/ })]
+  // then re-capture the baseline. See docs/visual-qa.md.
+  test('@visual landing matches baseline', async ({ page }) => {
+    await gotoSettledLanding(page);
+    await expect(page).toHaveScreenshot('landing.png', { fullPage: true });
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,8 @@
     "e2e:pr": "playwright test --project=chromium --grep-invert @nightly",
     "e2e:repeat5": "playwright test --project=chromium --repeat-each=5",
     "e2e:nightly": "playwright test --project=chromium --grep @nightly",
+    "e2e:visual": "E2E_REUSE_SERVER=1 playwright test --project=visual",
+    "e2e:visual:update": "E2E_REUSE_SERVER=1 playwright test --project=visual --update-snapshots",
     "e2e:report": "playwright show-report",
     "generate:firestore-types": "node ../../scripts/generate-firestore-types.mjs",
     "seed:jobs": "node ./scripts/seed-firestore-jobs.mjs"

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -20,7 +20,20 @@ const apiHealthURL = `${process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhos
 export default defineConfig({
   testDir: './e2e',
   timeout: 60_000,
-  expect: { timeout: 10_000 },
+  expect: {
+    timeout: 10_000,
+    // Post-deploy visual QA defaults. Freeze animations/caret so the
+    // paper-in-paper frame transitions don't produce mid-flight diffs, and
+    // absorb sub-pixel anti-aliasing noise between runs.
+    toHaveScreenshot: {
+      animations: 'disabled',
+      caret: 'hide',
+      maxDiffPixelRatio: 0.01,
+    },
+  },
+  // Keep visual baselines in a stable, greppable location so CI can upload
+  // freshly-captured snapshots as an artifact for a human to commit.
+  snapshotPathTemplate: '{testDir}/__screenshots__/{testFileName}/{arg}{ext}',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -38,11 +51,22 @@ export default defineConfig({
     { name: 'setup', testMatch: /auth\.setup\.ts/ },
     {
       name: 'chromium',
+      // Visual specs run in their own project against a live deploy — keep them
+      // out of the emulator-backed suite.
+      testIgnore: /\.visual\.ts/,
       use: {
         ...devices['Desktop Chrome'],
         storageState: authFile,
       },
       dependencies: ['setup'],
+    },
+    {
+      // Post-deploy visual QA: runs against E2E_BASE_URL (a live stage/prod
+      // deploy), unauthenticated, with no emulator setup dependency. The fixed
+      // Desktop Chrome viewport keeps screenshots deterministic across runs.
+      name: 'visual',
+      testMatch: /\.visual\.ts/,
+      use: { ...devices['Desktop Chrome'] },
     },
   ],
   webServer: process.env.E2E_REUSE_SERVER

--- a/docs/architecture/visual-qa.md
+++ b/docs/architecture/visual-qa.md
@@ -1,0 +1,74 @@
+# Post-Deploy Visual QA
+
+## Purpose
+
+After a **stage** frontend deploy, automatically exercise the live site in a real
+browser to reduce manual QA. This complements the curl-based
+[smoke tests](./stage-prod-smoke-tests.md), which confirm a `200` but cannot see
+a blank page, a JS-crashed shell, or unintended UI drift.
+
+Two layers, both in `apps/web/e2e/deploy-smoke.visual.ts`:
+
+- **A — liveness (`@smoke`)**: the landing page mounts, emits no console/page
+  errors, and shows the brand chrome + the unauthenticated `Google でログイン`
+  CTA.
+- **B — visual regression (`@visual`)**: the settled landing is compared against
+  a committed baseline screenshot.
+
+Phase 1 covers only the **unauthenticated** surface. Authenticated screens need a
+seeded stage QA account and are deferred to Phase 2 (see
+`issues/tickets/visual-qa-phase2.md`).
+
+## Execution
+
+The `visual-qa` job in `.github/workflows/deploy-frontend.yml` runs after a
+successful stage deploy:
+
+1. Installs deps + the Chromium browser.
+2. Runs `bun run e2e:visual`, which sets `E2E_REUSE_SERVER=1` (no local compose
+   stack) and points Playwright's `visual` project at the deployed site via
+   `E2E_BASE_URL` (the resolved Firebase Hosting URL, passed as a job output).
+3. On failure: uploads the diff report + snapshots as the `visual-qa-report`
+   artifact and posts a Discord alert (with diff images attached) via
+   `scripts/notify-visual-diff.mjs` to `DISCORD_ALERT_WEBHOOK_URL`.
+
+Determinism is enforced by the `visual` project's fixed Desktop Chrome viewport
+and the project-wide `toHaveScreenshot` defaults (`animations: 'disabled'`,
+`caret: 'hide'`, `maxDiffPixelRatio: 0.01`) in `playwright.config.ts`.
+
+## Baselines
+
+Baselines live in `apps/web/e2e/__screenshots__/` and **must be generated on
+Linux** (the CI OS) — snapshots captured on macOS/Windows/WSL will not match CI
+rendering. Do not commit locally-generated baselines.
+
+### Capturing / updating a baseline
+
+1. Trigger a stage deploy. The first `visual-qa` run has no baseline, so the
+   `@visual` test fails and Playwright writes the fresh baseline into the
+   uploaded `visual-qa-report` artifact.
+2. Download the artifact, review the captured PNGs, and commit them under
+   `apps/web/e2e/__screenshots__/`.
+3. The next deploy compares against them.
+
+For an **intended** UI change, regenerate the same way (or run
+`bun run e2e:visual:update` in a Linux CI context), review the diff, and commit
+the new baseline in the same PR as the UI change. Without this discipline the
+`@visual` check goes permanently red and stops being trusted.
+
+### Handling flaky regions
+
+If a live environment surfaces a genuinely non-deterministic region (e.g. a demo
+document image that varies), add a `mask:` for it in the `@visual` test and
+re-capture the baseline. See the inline note in `deploy-smoke.visual.ts`.
+
+## Required secrets / vars
+
+- `DISCORD_ALERT_WEBHOOK_URL` (secret, stage environment) — reused from the
+  readiness monitor; where regression alerts are posted.
+
+## Phase 2 (not in this change)
+
+- Dedicated stage QA account + storageState for authenticated screens.
+- Fixed Firestore seed (reset → seed) so list/detail views are deterministic.
+- Expand `@visual` coverage to key authenticated screens with timestamp masking.

--- a/issues/tickets/visual-qa-phase2.md
+++ b/issues/tickets/visual-qa-phase2.md
@@ -1,0 +1,29 @@
+# Post-Deploy Visual QA — Phase 2(認証後画面)
+
+## 背景
+
+Phase 1 で stage デプロイ後の**未認証**画面(ランディング)に対する自動 QA を導入した(生存確認 `@smoke` + 視覚差分 `@visual`)。詳細は [docs/architecture/visual-qa.md](../../docs/architecture/visual-qa.md)。
+
+Phase 2 では**認証後の主要画面**まで視覚差分の対象を広げ、QA の手動確認をさらに削減する。
+
+## 課題
+
+認証後画面を実 stage 相手に撮影するには「毎回同じ画面になる」保証が要る。現状の e2e 認証は Firebase Auth **エミュレータ**前提(`createTestUser` / `auth.setup.ts`)で、実 stage には使えない。
+
+## やること
+
+1. **専用 stage QA アカウント**を1つ用意し、資格情報を stage environment の secret(`E2E_QA_EMAIL` / `E2E_QA_PASSWORD` 等)に登録。
+2. `visual` プロジェクト用に、実 stage へログインして `storageState` を生成する setup を追加(エミュレータ用 `auth.setup.ts` とは分離)。
+3. **固定 Firestore シード**: `scripts/seed-firestore-jobs.mjs` を stage QA ユーザー向けに流用し、`visual-qa` job の頭で「リセット→シード」。一覧/詳細系を決定的にする。
+4. 相対時刻・ランダムID等の残存非決定要素は `mask:` で塗る。
+5. `@visual` の対象に主要な認証後画面(ワークスペース等)を追加し、Linux CI でベースラインを確定。
+
+## 判断ポイント
+
+- シードのリセット運用が重い/リスクがある場合は、認証後スコープを「空状態・設定画面」などデータ非依存の画面に絞るのが現実解。
+- prod への横展開は stage でフレーキー率が十分低いと確認できてから。
+
+## 関連
+
+- Phase 1 実装: `apps/web/e2e/deploy-smoke.visual.ts`, `.github/workflows/deploy-frontend.yml`(`visual-qa` job)
+- [e2e-test-expansion.md](./e2e-test-expansion.md)

--- a/scripts/notify-visual-diff.mjs
+++ b/scripts/notify-visual-diff.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Post a Discord alert when post-deploy visual QA finds a diff, attaching the
+// actual diff image(s) so QA can eyeball the regression without downloading the
+// CI artifact. Mirrors the embed style used by readiness-monitor.yml, but adds
+// multipart file attachments (which the reusable notify-discord.yml can't do).
+//
+// Invoked from the deploy-frontend `visual-qa` job on failure(). It is
+// deliberately resilient: a missing webhook or no diff files is a no-op (the
+// failing test is the real signal), but a webhook send error exits non-zero so
+// a broken notifier is visible in the job log.
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+const MAX_ATTACHMENTS = 4; // Discord allows 10; keep alerts skimmable.
+
+const {
+  DISCORD_ALERT_WEBHOOK_URL,
+  ENVIRONMENT = 'unknown',
+  FRONTEND_URL = '',
+  GITHUB_SERVER_URL = 'https://github.com',
+  GITHUB_REPOSITORY = '',
+  GITHUB_RUN_ID = '',
+  GITHUB_SHA = '',
+  GITHUB_REF_NAME = '',
+  GITHUB_ACTOR = '',
+} = process.env;
+
+const RESULTS_DIR = process.env.VISUAL_RESULTS_DIR ?? 'apps/web/test-results';
+
+async function findDiffImages(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out; // dir may not exist if the run crashed before writing results
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await findDiffImages(full)));
+    } else if (entry.name.endsWith('-diff.png')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+async function main() {
+  if (!DISCORD_ALERT_WEBHOOK_URL) {
+    console.warn('notify-visual-diff: DISCORD_ALERT_WEBHOOK_URL not set, skipping.');
+    return;
+  }
+
+  const diffs = (await findDiffImages(RESULTS_DIR)).slice(0, MAX_ATTACHMENTS);
+  const runUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+  const shortSha = GITHUB_SHA.slice(0, 7);
+
+  const description = [
+    `**${ENVIRONMENT}**${FRONTEND_URL ? ` — ${FRONTEND_URL}` : ''}`,
+    `Commit \`${shortSha || 'unknown'}\` on \`${GITHUB_REF_NAME}\` (by \`${GITHUB_ACTOR}\`)`,
+    diffs.length
+      ? `${diffs.length} screen(s) diverged from baseline. Diff image(s) attached.`
+      : 'Visual QA failed but no diff image was produced — check the run log (likely a liveness/@smoke failure or a missing baseline).',
+  ].join('\n');
+
+  const embed = {
+    title: `🖼️ Visual QA regression: ${ENVIRONMENT}`,
+    description,
+    url: runUrl,
+    color: 15158332, // red, matching the other alert embeds
+  };
+
+  const form = new FormData();
+  form.append('payload_json', JSON.stringify({ embeds: [embed] }));
+  for (let i = 0; i < diffs.length; i++) {
+    const buf = await readFile(diffs[i]);
+    form.append(
+      `files[${i}]`,
+      new Blob([buf], { type: 'image/png' }),
+      path.basename(diffs[i]),
+    );
+  }
+
+  const res = await fetch(DISCORD_ALERT_WEBHOOK_URL, { method: 'POST', body: form });
+  if (!res.ok) {
+    throw new Error(`Discord webhook returned ${res.status}: ${await res.text()}`);
+  }
+  console.log(`notify-visual-diff: alert sent (${diffs.length} attachment(s)).`);
+}
+
+main().catch((err) => {
+  console.error('notify-visual-diff:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## 目的

stage デプロイ後に自動でブラウザ撮影 + 検査を回し、**QA の手動確認を削減**する。curl ベースの smoke test では拾えない「真っ白 / JS クラッシュ / 意図しない UI ドリフト」を自動検知する。

`deploy-frontend` の `deploy` 成功後に `visual-qa` ジョブを追加(stage 限定、`needs: deploy`)。

## 中身(Phase 1: 未認証画面)

`apps/web/e2e/deploy-smoke.visual.ts` に2層:

- **A — 生存確認 (`@smoke`)**: ランディングがマウントし、console/page エラーゼロ、ブランドヘッダー + 未認証 CTA(`Google でログイン`)が表示される。
- **B — 視覚差分 (`@visual`)**: 落ち着いたランディングのフルページを、コミット済みベースラインと比較。`animations: 'disabled'` / caret 固定 / 固定ビューポートで決定的に。

paper-in-paper の Canvas は実 DOM なのでアニメ確定後なら比較可能。フレーキー領域が出たら `mask:` で塗ってベースライン再取得(方法は `docs/architecture/visual-qa.md`)。

## 通知

失敗時に `visual-qa-report`(diff レポート + 取得済みベースライン)を artifact アップロードし、**diff 画像を添付して Discord へ**(`DISCORD_ALERT_WEBHOOK_URL`、readiness-monitor と同じ webhook)。添付には既存の再利用 workflow が使えないため `scripts/notify-visual-diff.mjs` を新設。

## ベースライン運用(重要)

- ベースラインは **Linux(CI OS)で生成**し `apps/web/e2e/__screenshots__/` にコミット。ローカル(mac/WSL)生成はレンダリング差でズレるので禁止。
- 初回 stage デプロイで `@visual` は baseline 不在により失敗 → artifact から取得済み PNG をレビューしてコミット → 次回以降が比較対象になる。
- 意図した UI 変更時は同じ手順(または CI 上 `bun run e2e:visual:update`)で再取得し、差分画像をレビューして UI 変更と同じ PR にコミット。

## マージ前に必要な設定

- stage environment の secret `DISCORD_ALERT_WEBHOOK_URL`(readiness-monitor で登録済みなら流用可)。
- 初回デプロイ後にベースライン PNG をコミット(上記手順)。それまで `@visual` は赤。

## スコープ外(Phase 2)

認証後の主要画面の視覚差分は、専用 stage QA アカウント + Firestore 固定シードが要るため別チケットに分離: `issues/tickets/visual-qa-phase2.md`。prod への横展開も stage 安定確認後。

## テスト

- `tsc --noEmit` / `eslint`: 新規ファイル(`deploy-smoke.visual.ts`, `playwright.config.ts`)エラーなし。
- workflow YAML / notifier(`node --check`)/ package.json: 構文検証済み。
- 実 stage に対する初回実行はマージ後に発生(ベースライン取得を兼ねる)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
