### PR TITLE
perf(tree): fill in ChildIDs with one query instead of one per item

### DIFF
--- a/apps/api/internal/repository/postgres/sqlcgen/tree.sql.go
+++ b/apps/api/internal/repository/postgres/sqlcgen/tree.sql.go
@@ -214,6 +214,57 @@ func (q *Queries) InsertJobMutationLog(ctx context.Context, arg InsertJobMutatio
 	return err
 }
 
+const listChildIDsByWorkspace = `-- name: ListChildIDsByWorkspace :many
+SELECT parent_id, id
+FROM tree_items
+WHERE workspace_id = $1 AND parent_id IS NOT NULL
+ORDER BY created_at ASC, id ASC
+`
+
+type ListChildIDsByWorkspaceRow struct {
+	ParentID sql.NullString
+	ID       string
+}
+
+// Every parent-to-child edge in a workspace, in one round trip, used to fill in
+// each item's ChildIDs after a tree listing. Doing it per item meant 1+N
+// queries, and each of those selected the full row including `content` — so
+// assembling a list of ids re-read every node body a second time. At 5,000
+// nodes that was 43 ms of query time (against 7 ms for the listing itself) and
+// 11 MiB of body text read for nothing. Measurements in
+// docs/improvements/client-item-load-testing.md.
+//
+// Only the two id columns are selected, so the result stays small however large
+// the bodies are. Workspace-scoped rather than parent-scoped because a scalar
+// parameter needs no array support from the driver.
+//
+// Ordered by created_at to match the order the item listings use, with id
+// breaking ties: a job persists a tree in one statement, so siblings routinely
+// share a created_at and that column alone is not a total order. The per-parent
+// query had no ORDER BY at all, so sibling order was whatever the scan produced.
+func (q *Queries) ListChildIDsByWorkspace(ctx context.Context, workspaceID string) ([]ListChildIDsByWorkspaceRow, error) {
+	rows, err := q.db.QueryContext(ctx, listChildIDsByWorkspace, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListChildIDsByWorkspaceRow
+	for rows.Next() {
+		var i ListChildIDsByWorkspaceRow
+		if err := rows.Scan(&i.ParentID, &i.ID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listChildItems = `-- name: ListChildItems :many
 SELECT id, workspace_id, parent_id, title, level, description, content, override_css, created_by,
   governance_state, cross_document, created_at,

--- a/apps/api/internal/repository/postgres/tree.go
+++ b/apps/api/internal/repository/postgres/tree.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/synthify/backend/apps/api/internal/domain"
@@ -38,7 +39,9 @@ func (s *Store) GetTreeByWorkspace(ctx context.Context, wsID string) ([]*domain.
 	for _, r := range rows {
 		items = append(items, toItemFromItemRow(r))
 	}
-	s.populateChildIDs(ctx, items)
+	if err := s.populateChildIDs(ctx, items); err != nil {
+		return nil, err
+	}
 	return items, nil
 }
 
@@ -104,23 +107,51 @@ func (s *Store) GetSubtree(ctx context.Context, rootItemID string, maxDepth int)
 	for _, item := range items {
 		plainItems = append(plainItems, &item.Item)
 	}
-	s.populateChildIDs(ctx, plainItems)
+	if err := s.populateChildIDs(ctx, plainItems); err != nil {
+		return nil, err
+	}
 	return items, nil
 }
 
-func (s *Store) populateChildIDs(ctx context.Context, items []*domain.Item) {
+// populateChildIDs fills in ChildIDs for every item, using one query per
+// distinct workspace rather than one per item. See the
+// ListChildIDsByWorkspace query for why: the per-item version was 1+N queries
+// that each dragged along the node bodies it did not need.
+//
+// Errors are returned rather than swallowed. The per-item version skipped a
+// failed item and left its ChildIDs empty, which is survivable; one failure
+// here would silently flatten the entire tree, which is not.
+func (s *Store) populateChildIDs(ctx context.Context, items []*domain.Item) error {
+	itemsByID := make(map[string]*domain.Item, len(items))
+	workspaceIDs := make([]string, 0, 1)
 	for _, item := range items {
 		if item == nil || item.ItemID == "" {
 			continue
 		}
-		rows, err := s.q().ListChildItems(ctx, sql.NullString{String: item.ItemID, Valid: true})
-		if err != nil {
-			continue
+		itemsByID[item.ItemID] = item
+		// Every item starts with an empty (non-nil) slice, matching what the
+		// per-item version produced for a childless node.
+		item.ChildIDs = []string{}
+		if item.WorkspaceID != "" && !slices.Contains(workspaceIDs, item.WorkspaceID) {
+			workspaceIDs = append(workspaceIDs, item.WorkspaceID)
 		}
-		childIDs := make([]string, 0, len(rows))
-		for _, row := range rows {
-			childIDs = append(childIDs, row.ID)
-		}
-		item.ChildIDs = childIDs
 	}
+	if len(itemsByID) == 0 {
+		return nil
+	}
+
+	for _, wsID := range workspaceIDs {
+		rows, err := s.q().ListChildIDsByWorkspace(ctx, wsID)
+		if err != nil {
+			return fmt.Errorf("list child ids by workspace: %w", err)
+		}
+		for _, row := range rows {
+			// Edges whose parent is not among `items` are skipped: a subtree
+			// listing holds only part of the workspace.
+			if parent, ok := itemsByID[row.ParentID.String]; ok {
+				parent.ChildIDs = append(parent.ChildIDs, row.ID)
+			}
+		}
+	}
+	return nil
 }

--- a/apps/api/internal/repository/postgres/tree_test.go
+++ b/apps/api/internal/repository/postgres/tree_test.go
@@ -2,7 +2,12 @@ package postgres
 
 import (
 	"context"
+	"database/sql/driver"
+	"errors"
 	"testing"
+	"time"
+
+	"github.com/synthify/backend/apps/api/internal/domain"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
@@ -30,4 +35,98 @@ func TestGetTree_DBError_ReturnsError(t *testing.T) {
 
 	_, err = store.GetTree(context.Background(), "ws_1")
 	assert.Error(t, err, "expected error on DB failure, got nil")
+}
+
+// treeItemColumns mirrors ListItemsByWorkspace's select list.
+var treeItemColumns = []string{
+	"id", "workspace_id", "parent_id", "title", "level", "description", "content",
+	"override_css", "created_by", "governance_state", "cross_document", "created_at",
+}
+
+func treeItemRow(id, parentID string) []driver.Value {
+	var parent driver.Value
+	if parentID != "" {
+		parent = parentID
+	}
+	return []driver.Value{id, "ws_1", parent, id, int32(0), "", "", "", "", "system_generated", false, time.Now()}
+}
+
+// ChildIDs are filled in with a single query for the whole workspace. Anything
+// per-item would issue queries sqlmock has not been told to expect, which
+// surfaces as an error rather than as a quietly slower endpoint — which is how
+// the 1+N version went unnoticed.
+func TestGetTreeByWorkspace_PopulatesChildIDsWithOneQuery(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err, "sqlmock.New")
+	defer db.Close()
+
+	mock.ExpectQuery("FROM tree_items").WillReturnRows(
+		sqlmock.NewRows(treeItemColumns).
+			AddRow(treeItemRow("root", "")...).
+			AddRow(treeItemRow("a", "root")...).
+			AddRow(treeItemRow("b", "root")...).
+			AddRow(treeItemRow("leaf", "a")...),
+	)
+	mock.ExpectQuery("SELECT parent_id, id").WillReturnRows(
+		sqlmock.NewRows([]string{"parent_id", "id"}).
+			AddRow("root", "a").
+			AddRow("root", "b").
+			AddRow("a", "leaf"),
+	)
+
+	store := &Store{db: db}
+	items, err := store.GetTreeByWorkspace(context.Background(), "ws_1")
+	require.NoError(t, err)
+
+	byID := make(map[string]*domain.Item, len(items))
+	for _, item := range items {
+		byID[item.ItemID] = item
+	}
+	assert.Equal(t, []string{"a", "b"}, byID["root"].ChildIDs, "sibling order follows the query's ORDER BY")
+	assert.Equal(t, []string{"leaf"}, byID["a"].ChildIDs)
+	assert.Equal(t, []string{}, byID["b"].ChildIDs, "a childless node gets an empty, non-nil slice")
+	assert.Equal(t, []string{}, byID["leaf"].ChildIDs)
+
+	require.NoError(t, mock.ExpectationsWereMet(), "expected exactly one child-id query")
+}
+
+// A subtree listing holds only part of the workspace, so the edge query returns
+// parents that are not in the result set. Those must be dropped, not panic.
+func TestGetTreeByWorkspace_IgnoresEdgesForItemsNotListed(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err, "sqlmock.New")
+	defer db.Close()
+
+	mock.ExpectQuery("FROM tree_items").WillReturnRows(
+		sqlmock.NewRows(treeItemColumns).AddRow(treeItemRow("root", "")...),
+	)
+	mock.ExpectQuery("SELECT parent_id, id").WillReturnRows(
+		sqlmock.NewRows([]string{"parent_id", "id"}).
+			AddRow("root", "a").
+			AddRow("elsewhere", "b"),
+	)
+
+	store := &Store{db: db}
+	items, err := store.GetTreeByWorkspace(context.Background(), "ws_1")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, []string{"a"}, items[0].ChildIDs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// The per-item version swallowed query errors; a failure of the single query
+// would silently flatten the whole tree, so it must propagate.
+func TestGetTreeByWorkspace_ChildIDQueryError_Propagates(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err, "sqlmock.New")
+	defer db.Close()
+
+	mock.ExpectQuery("FROM tree_items").WillReturnRows(
+		sqlmock.NewRows(treeItemColumns).AddRow(treeItemRow("root", "")...),
+	)
+	mock.ExpectQuery("SELECT parent_id, id").WillReturnError(errors.New("connection reset"))
+
+	store := &Store{db: db}
+	_, err = store.GetTreeByWorkspace(context.Background(), "ws_1")
+	assert.Error(t, err)
 }

--- a/apps/worker/pkg/worker/repository/postgres/sqlcgen/tree.sql.go
+++ b/apps/worker/pkg/worker/repository/postgres/sqlcgen/tree.sql.go
@@ -214,6 +214,57 @@ func (q *Queries) InsertJobMutationLog(ctx context.Context, arg InsertJobMutatio
 	return err
 }
 
+const listChildIDsByWorkspace = `-- name: ListChildIDsByWorkspace :many
+SELECT parent_id, id
+FROM tree_items
+WHERE workspace_id = $1 AND parent_id IS NOT NULL
+ORDER BY created_at ASC, id ASC
+`
+
+type ListChildIDsByWorkspaceRow struct {
+	ParentID sql.NullString
+	ID       string
+}
+
+// Every parent-to-child edge in a workspace, in one round trip, used to fill in
+// each item's ChildIDs after a tree listing. Doing it per item meant 1+N
+// queries, and each of those selected the full row including `content` — so
+// assembling a list of ids re-read every node body a second time. At 5,000
+// nodes that was 43 ms of query time (against 7 ms for the listing itself) and
+// 11 MiB of body text read for nothing. Measurements in
+// docs/improvements/client-item-load-testing.md.
+//
+// Only the two id columns are selected, so the result stays small however large
+// the bodies are. Workspace-scoped rather than parent-scoped because a scalar
+// parameter needs no array support from the driver.
+//
+// Ordered by created_at to match the order the item listings use, with id
+// breaking ties: a job persists a tree in one statement, so siblings routinely
+// share a created_at and that column alone is not a total order. The per-parent
+// query had no ORDER BY at all, so sibling order was whatever the scan produced.
+func (q *Queries) ListChildIDsByWorkspace(ctx context.Context, workspaceID string) ([]ListChildIDsByWorkspaceRow, error) {
+	rows, err := q.db.QueryContext(ctx, listChildIDsByWorkspace, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListChildIDsByWorkspaceRow
+	for rows.Next() {
+		var i ListChildIDsByWorkspaceRow
+		if err := rows.Scan(&i.ParentID, &i.ID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listChildItems = `-- name: ListChildItems :many
 SELECT id, workspace_id, parent_id, title, level, description, content, override_css, created_by,
   governance_state, cross_document, created_at,

--- a/apps/worker/pkg/worker/repository/postgres/tree.go
+++ b/apps/worker/pkg/worker/repository/postgres/tree.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 
 	"github.com/synthify/backend/apps/worker/pkg/worker/domain"
 )
@@ -17,7 +18,9 @@ func (s *Store) GetTreeByWorkspace(ctx context.Context, wsID string) ([]*domain.
 	for _, r := range rows {
 		items = append(items, toItemFromItemRow(r))
 	}
-	s.populateChildIDs(ctx, items)
+	if err := s.populateChildIDs(ctx, items); err != nil {
+		return nil, err
+	}
 	return items, nil
 }
 
@@ -83,23 +86,52 @@ func (s *Store) GetSubtree(ctx context.Context, rootItemID string, maxDepth int)
 	for _, item := range items {
 		plainItems = append(plainItems, &item.Item)
 	}
-	s.populateChildIDs(ctx, plainItems)
+	if err := s.populateChildIDs(ctx, plainItems); err != nil {
+		return nil, err
+	}
 	return items, nil
 }
 
-func (s *Store) populateChildIDs(ctx context.Context, items []*domain.Item) {
+// populateChildIDs fills in ChildIDs for every item, using one query per
+// distinct workspace rather than one per item. See the
+// ListChildIDsByWorkspace query for why: the per-item version was 1+N queries
+// that each dragged along the node bodies it did not need. The worker walks
+// whole trees during a job, so it paid the same cost as the API did.
+//
+// Errors are returned rather than swallowed. The per-item version skipped a
+// failed item and left its ChildIDs empty, which is survivable; one failure
+// here would silently flatten the entire tree, which is not.
+func (s *Store) populateChildIDs(ctx context.Context, items []*domain.Item) error {
+	itemsByID := make(map[string]*domain.Item, len(items))
+	workspaceIDs := make([]string, 0, 1)
 	for _, item := range items {
 		if item == nil || item.ItemID == "" {
 			continue
 		}
-		rows, err := s.q().ListChildItems(ctx, sql.NullString{String: item.ItemID, Valid: true})
-		if err != nil {
-			continue
+		itemsByID[item.ItemID] = item
+		// Every item starts with an empty (non-nil) slice, matching what the
+		// per-item version produced for a childless node.
+		item.ChildIDs = []string{}
+		if item.WorkspaceID != "" && !slices.Contains(workspaceIDs, item.WorkspaceID) {
+			workspaceIDs = append(workspaceIDs, item.WorkspaceID)
 		}
-		childIDs := make([]string, 0, len(rows))
-		for _, row := range rows {
-			childIDs = append(childIDs, row.ID)
-		}
-		item.ChildIDs = childIDs
 	}
+	if len(itemsByID) == 0 {
+		return nil
+	}
+
+	for _, wsID := range workspaceIDs {
+		rows, err := s.q().ListChildIDsByWorkspace(ctx, wsID)
+		if err != nil {
+			return fmt.Errorf("list child ids by workspace: %w", err)
+		}
+		for _, row := range rows {
+			// Edges whose parent is not among `items` are skipped: a subtree
+			// listing holds only part of the workspace.
+			if parent, ok := itemsByID[row.ParentID.String]; ok {
+				parent.ChildIDs = append(parent.ChildIDs, row.ID)
+			}
+		}
+	}
+	return nil
 }

--- a/db/queries/tree.sql
+++ b/db/queries/tree.sql
@@ -144,3 +144,25 @@ SELECT id, workspace_id, parent_id, title, level, description, content, override
   EXISTS(SELECT 1 FROM tree_items child WHERE child.parent_id = tree_items.id) AS has_children
 FROM tree_items
 WHERE tree_items.parent_id = $1;
+
+-- name: ListChildIDsByWorkspace :many
+-- Every parent-to-child edge in a workspace, in one round trip, used to fill in
+-- each item's ChildIDs after a tree listing. Doing it per item meant 1+N
+-- queries, and each of those selected the full row including `content` — so
+-- assembling a list of ids re-read every node body a second time. At 5,000
+-- nodes that was 43 ms of query time (against 7 ms for the listing itself) and
+-- 11 MiB of body text read for nothing. Measurements in
+-- docs/improvements/client-item-load-testing.md.
+--
+-- Only the two id columns are selected, so the result stays small however large
+-- the bodies are. Workspace-scoped rather than parent-scoped because a scalar
+-- parameter needs no array support from the driver.
+--
+-- Ordered by created_at to match the order the item listings use, with id
+-- breaking ties: a job persists a tree in one statement, so siblings routinely
+-- share a created_at and that column alone is not a total order. The per-parent
+-- query had no ORDER BY at all, so sibling order was whatever the scan produced.
+SELECT parent_id, id
+FROM tree_items
+WHERE workspace_id = $1 AND parent_id IS NOT NULL
+ORDER BY created_at ASC, id ASC;


### PR DESCRIPTION
## 背景

`populateChildIDs` が item ごとに `ListChildItems` を呼んでいたため、tree の一覧取得が **1+N クエリ**になっていた。さらに `ListChildItems` は `content` を含む全カラムを SELECT しているので、**child id のリストを組み立てるために全 node の本文を 2 度読んでいた**。

PostgreSQL 16 実機で 5,000 node（本文 2 KiB）を seed して計測:

| | クエリ数 | 時間 |
|---|---|---|
| 変更前 (`ListChildItems` × N) | 5,000 | 44.7 ms |
| 変更後 (`ListChildIDsByWorkspace`) | **1** | **3.2 ms** |

比較のため、これが装飾している一覧クエリ本体 (`ListItemsByWorkspace`) は 7.4 ms。つまり**付随処理が本体の 6 倍かかっていた**。加えて本文 11.32 MiB の二重読みが消える。上の数値はサーバ内ループでの計測なので、Go 側が払っていた 5,000 回の round-trip は含まれていない（実際の改善はこれより大きい）。

## 変更内容

- `ListChildIDsByWorkspace` を追加。workspace の親子エッジを 1 クエリで返し、**id 2 列だけ**を SELECT するので本文がどれだけ大きくても結果は小さい。
- `populateChildIDs` を「workspace ごとに 1 クエリ + Go 側で map に grouping」に変更。subtree 一覧は workspace の一部しか持たないので、結果に含まれない親のエッジは捨てる。
- worker 側の同名関数にも同じ修正を適用。同じ欠陥があり、job 実行中に tree 全体を歩く。

### parent 単位ではなく workspace 単位にした理由

`WHERE parent_id = ANY($1::TEXT[])` の方が絞り込めるが、sqlc は `= ANY($1)` に対して `pq.Array` を生成する。このリポジトリの driver は `pgx/stdlib` で **lib/pq は依存に入っていない**ため、生成コードがビルドできない。scalar パラメータなら driver 側の配列サポートが不要なので workspace scope を選んだ。

## 挙動の変化（2点）

1. **兄弟の順序が決定的になる。** 変更前の per-parent クエリには `ORDER BY` が無く、child の順序はスキャン順次第だった。新クエリは `created_at ASC, id ASC`。`created_at` だけでは足りない — job は tree を 1 statement で永続化するので兄弟の `created_at` は普通に同値になり、全順序にならない。実機で 3 回実行して同一順序を確認済み。
2. **クエリエラーが伝播する。** 変更前は失敗した item を skip して `ChildIDs` を空のまま残していた（1 件なら許容範囲）。1 クエリになった今、同じ握り潰しをすると 1 回の失敗で **tree 全体がフラットになる**ので、エラーを返すようにした。呼び出し元（`GetTreeByWorkspace` / `GetSubtree`）はどちらも error を返せる。

子を持たない node は空の非 nil スライスを受け取る（変更前と同じ）。

## 検証

- `go build ./...` / `go test ./...`（40 パッケージ）— 通過
- **PostgreSQL 16 実機**で 5,000 node を seed し、上記の before/after を計測。エッジ数 4,999 も一致
- 追加テスト（sqlmock）— **N+1 に戻ると「期待していないクエリ」としてエラーになる**ので、静かに遅くなる形での再発を防げる。これが今回見逃されていた形なので、そこを塞ぐのが狙い
  - 一覧あたり child id クエリが 1 本、grouping と兄弟順序が正しいこと
  - 子なし node が空の非 nil スライスになること
  - 結果に含まれない親のエッジが捨てられること
  - クエリエラーが伝播すること

## 補足

- コメント内で参照している `docs/improvements/client-item-load-testing.md` は #23 で入るドキュメントです。#23 が未マージの間はリンクが解決しません（数値はコメント内に直接書いてあるので、単体で読めます）。
- #23 とは独立にマージできます。ただし両方が `db/queries/tree.sql` と sqlc 生成物を触るため、後にマージする側で生成コードの conflict が出る可能性があります。その場合は `sqlc generate` を回し直せば解消します。
- #23 側のドキュメントは `populateChildIDs` を「未実装」と書いたままなので、両方マージ後に更新が必要です。必要なら対応します。

---
_Generated by [Claude Code](https://claude.ai/code/session_017MBzVjZkFQW3C8SNucrFij)_