### PR TITLE
fix(terraform): set cpu_idle so Cloud Run services bill per request

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,6 +11,11 @@ on:
       - go.mod
       - go.sum
       - sqlc.yaml
+      # The terraform job below is the only fmt/validate gate there is, so a
+      # change under terraform/ has to be able to trigger it. Without this a
+      # terraform-only PR merged with no validation at all, and the first thing
+      # to parse it was `terraform apply` against a real environment.
+      - terraform/**
       - .github/workflows/backend.yml
   push:
     branches:
@@ -24,6 +29,7 @@ on:
       - go.mod
       - go.sum
       - sqlc.yaml
+      - terraform/**
       - .github/workflows/backend.yml
 
 jobs:

--- a/terraform/modules/cloud_run_service/main.tf
+++ b/terraform/modules/cloud_run_service/main.tf
@@ -36,6 +36,10 @@ resource "google_cloud_run_v2_service" "this" {
           cpu    = var.cpu
           memory = var.memory
         }
+        # Always set explicitly: the provider only infers true when `resources`
+        # is omitted altogether. See the cpu_idle variable for the billing
+        # consequences of getting this wrong.
+        cpu_idle = var.cpu_idle
       }
 
       ports {

--- a/terraform/modules/cloud_run_service/variables.tf
+++ b/terraform/modules/cloud_run_service/variables.tf
@@ -57,6 +57,25 @@ variable "min_instance_count" {
   default = 0
 }
 
+# CPU allocation / billing mode. true = CPU is only allocated while a request is
+# in flight (request-based billing); false = CPU is always allocated for the
+# whole instance lifetime (instance-based billing).
+#
+# This MUST stay explicit. google_cloud_run_v2_service only defaults cpu_idle to
+# true when the `resources` block is absent entirely; because this module always
+# sets resources.limits, leaving cpu_idle unset makes the provider send false and
+# the service is billed for every second an instance is alive, even idle ones —
+# min_instance_count=0 saves nothing once anything (a health probe, a scheduler)
+# keeps an instance warm. See hashicorp/terraform-provider-google#17246.
+#
+# Consequence of true: goroutines/timers that run outside a request are throttled
+# and must not be relied on. Periodic work belongs in Cloud Scheduler (see the
+# maintenance sweep in services/api) or a Cloud Run Job.
+variable "cpu_idle" {
+  type    = bool
+  default = true
+}
+
 variable "max_instance_count" {
   type    = number
   default = 2


### PR DESCRIPTION
## 何が問題か

Cloud Run の 3 サービス（api / worker / monitor）はいずれも `min_instance_count = 0` なのに、課金上は「常時起動」扱いになっていました。

`google_cloud_run_v2_service` が `cpu_idle` を true にフォールバックするのは **`resources` ブロック自体が無いときだけ**です。このモジュールは常に `resources.limits` を設定しているため、`cpu_idle` を明示しないと provider は `false` を送り、インスタンスは生存している全秒数（アイドル分を含む）が課金されます。→ [hashicorp/terraform-provider-google#17246](https://github.com/hashicorp/terraform-provider-google/issues/17246)

これが min-instances=0 なのに料金が下がらなかった理由です。readiness monitor が stage / prod を 5 分ごとに叩いており、Cloud Run はアイドルインスタンスを約 15 分保持するため、両環境でインスタンスが 24 時間生き続け、その間ずっと課金されていました。

## 変更

`cpu_idle` 変数（default `true`）をモジュールに追加し、`resources` ブロックで必ず送るようにしました。api / worker / monitor がリクエストベース課金になります。

3 サービスとも処理はリクエスト内で完結しているため副作用はありません。worker も Cloud Tasks ハンドラが完全に同期処理で、`go func` はテスト fixture のみです。

なぜ明示が必須なのか（および `true` にした結果リクエスト外の goroutine / timer に依存できなくなること）は変数のコメントに残してあります。

## マージ順序に関する注意

このモジュール変更を適用するとリクエスト外の CPU が絞られます。main の API には 5 分間隔の stuck-job ticker が入っているため、**main 上では #26（maintenance sweep の Cloud Scheduler 化）が先に入っているのが望ましい**です。

ただし現在 stage / prod にデプロイ済みのコードは `67f0c6e`（7/6）で、その ticker はまだ含まれておらず、起動 15 秒後の one-shot auto-resume のみです。そのため **stage / prod にこの変更だけを先行適用しても副作用はありません**。コスト出血を止めるため、そちらを先に実施します。

## 関連 PR

- #26 maintenance sweep の Cloud Scheduler 化（main 上での前提）
- #27 readiness monitor を 15 分間隔に（独立、順序依存なし）

## 検証

- `terraform fmt -recursive` clean
- `terraform validate` は未実行（実行環境のネットワークポリシーが `registry.terraform.io` を 403 で遮断しており provider を取得できませんでした）。CD の plan で確認します