### PR TITLE
feat(api): drive job housekeeping sweeps from Cloud Scheduler

### DIFF
--- a/apps/api/internal/auth/scheduler.go
+++ b/apps/api/internal/auth/scheduler.go
@@ -1,0 +1,89 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/idtoken"
+)
+
+// IDTokenValidator validates a Google-issued OIDC ID token against an expected
+// audience. Injected so tests do not have to reach Google's cert endpoint.
+type IDTokenValidator func(ctx context.Context, token, audience string) (*idtoken.Payload, error)
+
+type SchedulerAuthenticatorConfig struct {
+	// Audience the OIDC token must carry. Cloud Scheduler mints the token with
+	// the audience configured on the job; terraform sets it to the API's Cloud
+	// Run URL. Empty => the authenticator fails closed.
+	Audience string
+	// AllowedServiceAccountsCSV lists the service account emails permitted to
+	// call. Empty => fails closed, same posture as the admin allowlist.
+	AllowedServiceAccountsCSV string
+	// Validator defaults to idtoken.Validate.
+	Validator IDTokenValidator
+}
+
+// SchedulerAuthenticator authenticates Cloud Scheduler (or any Google OIDC)
+// callers on endpoints the Firebase middleware exempts. The API service is
+// deployed with allow_unauthenticated=true so Cloud Run IAM cannot gate these
+// routes; the check has to happen here.
+type SchedulerAuthenticator struct {
+	validate      IDTokenValidator
+	audience      string
+	allowedEmails map[string]bool
+}
+
+func NewSchedulerAuthenticator(cfg SchedulerAuthenticatorConfig) (*SchedulerAuthenticator, error) {
+	audience := strings.TrimSpace(cfg.Audience)
+	if audience == "" {
+		return nil, errors.New("scheduler authenticator: audience is required")
+	}
+	allowed := parseEmailSet(cfg.AllowedServiceAccountsCSV)
+	if len(allowed) == 0 {
+		return nil, errors.New("scheduler authenticator: at least one allowed service account is required")
+	}
+	validate := cfg.Validator
+	if validate == nil {
+		validate = idtoken.Validate
+	}
+	return &SchedulerAuthenticator{validate: validate, audience: audience, allowedEmails: allowed}, nil
+}
+
+// Authenticate verifies an Authorization header carrying a Google OIDC bearer
+// token. It returns ErrUnauthenticated when the token is absent or invalid and
+// ErrPermissionDenied when the token is valid but the caller is not allowlisted,
+// so the handler can map them to 401 vs 403.
+func (a *SchedulerAuthenticator) Authenticate(ctx context.Context, authorizationHeader string) (string, error) {
+	token := bearerToken(authorizationHeader)
+	if token == "" {
+		return "", fmt.Errorf("%w: missing bearer token", ErrUnauthenticated)
+	}
+	payload, err := a.validate(ctx, token, a.audience)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrUnauthenticated, err)
+	}
+	rawEmail, _ := payload.Claims["email"].(string)
+	email := lowerTrim(rawEmail)
+	if email == "" {
+		return "", fmt.Errorf("%w: token carries no email claim", ErrUnauthenticated)
+	}
+	// Google mints email_verified=true for service-account identities; a token
+	// without it is not one, so refuse rather than trust the email claim.
+	if verified, ok := payload.Claims["email_verified"].(bool); !ok || !verified {
+		return "", fmt.Errorf("%w: token email is not verified", ErrUnauthenticated)
+	}
+	if !a.allowedEmails[email] {
+		return "", fmt.Errorf("%w: %s is not an allowed caller", ErrPermissionDenied, email)
+	}
+	return email, nil
+}
+
+func bearerToken(header string) string {
+	const prefix = "bearer "
+	if !strings.HasPrefix(strings.ToLower(header), prefix) {
+		return ""
+	}
+	return strings.TrimSpace(header[len(prefix):])
+}

--- a/apps/api/internal/auth/scheduler_test.go
+++ b/apps/api/internal/auth/scheduler_test.go
@@ -1,0 +1,125 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/api/idtoken"
+)
+
+func serviceAccountPayload(email string, verified bool) *idtoken.Payload {
+	return &idtoken.Payload{
+		Claims: map[string]interface{}{
+			"email":          email,
+			"email_verified": verified,
+		},
+	}
+}
+
+func stubValidator(payload *idtoken.Payload, err error) IDTokenValidator {
+	return func(context.Context, string, string) (*idtoken.Payload, error) {
+		return payload, err
+	}
+}
+
+func newTestAuthenticator(t *testing.T, allowed string, validator IDTokenValidator) *SchedulerAuthenticator {
+	t.Helper()
+	a, err := NewSchedulerAuthenticator(SchedulerAuthenticatorConfig{
+		Audience:                  "https://api.example.com",
+		AllowedServiceAccountsCSV: allowed,
+		Validator:                 validator,
+	})
+	if err != nil {
+		t.Fatalf("NewSchedulerAuthenticator: %v", err)
+	}
+	return a
+}
+
+func TestNewSchedulerAuthenticator_FailsClosedWithoutConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		audience string
+		allowed  string
+	}{
+		{name: "no audience", allowed: "sched@example.iam.gserviceaccount.com"},
+		{name: "no allowlist", audience: "https://api.example.com"},
+		{name: "allowlist of blanks", audience: "https://api.example.com", allowed: " , "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewSchedulerAuthenticator(SchedulerAuthenticatorConfig{
+				Audience:                  tc.audience,
+				AllowedServiceAccountsCSV: tc.allowed,
+			}); err == nil {
+				t.Fatal("expected an error so the endpoint is never mounted half-configured")
+			}
+		})
+	}
+}
+
+func TestSchedulerAuthenticator_AcceptsAllowlistedServiceAccount(t *testing.T) {
+	const email = "Sched@example.iam.gserviceaccount.com"
+	a := newTestAuthenticator(t, "sched@example.iam.gserviceaccount.com",
+		stubValidator(serviceAccountPayload(email, true), nil))
+
+	caller, err := a.Authenticate(context.Background(), "Bearer token")
+	if err != nil {
+		t.Fatalf("expected the allowlisted caller to authenticate, got %v", err)
+	}
+	if caller != "sched@example.iam.gserviceaccount.com" {
+		t.Fatalf("expected the normalized email, got %q", caller)
+	}
+}
+
+func TestSchedulerAuthenticator_PassesConfiguredAudienceToValidator(t *testing.T) {
+	var gotAudience, gotToken string
+	a := newTestAuthenticator(t, "sched@example.iam.gserviceaccount.com",
+		func(_ context.Context, token, audience string) (*idtoken.Payload, error) {
+			gotToken, gotAudience = token, audience
+			return serviceAccountPayload("sched@example.iam.gserviceaccount.com", true), nil
+		})
+
+	if _, err := a.Authenticate(context.Background(), "Bearer abc123"); err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if gotToken != "abc123" {
+		t.Fatalf("expected the bearer value without the prefix, got %q", gotToken)
+	}
+	if gotAudience != "https://api.example.com" {
+		t.Fatalf("expected the configured audience, got %q", gotAudience)
+	}
+}
+
+func TestSchedulerAuthenticator_RejectsUnauthenticated(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		header  string
+		payload *idtoken.Payload
+		err     error
+	}{
+		{name: "missing header", payload: serviceAccountPayload("sched@example.iam.gserviceaccount.com", true)},
+		{name: "not a bearer header", header: "Basic abc", payload: serviceAccountPayload("sched@example.iam.gserviceaccount.com", true)},
+		{name: "invalid token", header: "Bearer abc", err: errors.New("audience mismatch")},
+		{name: "no email claim", header: "Bearer abc", payload: serviceAccountPayload("", true)},
+		{name: "unverified email", header: "Bearer abc", payload: serviceAccountPayload("sched@example.iam.gserviceaccount.com", false)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newTestAuthenticator(t, "sched@example.iam.gserviceaccount.com", stubValidator(tc.payload, tc.err))
+
+			_, err := a.Authenticate(context.Background(), tc.header)
+			if !errors.Is(err, ErrUnauthenticated) {
+				t.Fatalf("expected ErrUnauthenticated, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSchedulerAuthenticator_RejectsValidTokenFromOtherIdentity(t *testing.T) {
+	a := newTestAuthenticator(t, "sched@example.iam.gserviceaccount.com",
+		stubValidator(serviceAccountPayload("someone-else@example.iam.gserviceaccount.com", true), nil))
+
+	_, err := a.Authenticate(context.Background(), "Bearer abc")
+	if !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("expected ErrPermissionDenied so the handler answers 403, got %v", err)
+	}
+}

--- a/apps/api/internal/bootstrap/application.go
+++ b/apps/api/internal/bootstrap/application.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
 	"github.com/synthify/backend/apps/api/internal/application"
@@ -102,9 +101,6 @@ func NewApplication(ctx context.Context, cfg config.API, logger *slog.Logger, nr
 		Logger:           logger,
 		NRApp:            nrApp,
 	})
-	startAutoResume(documentSvc, logger)
-	startStuckJobMonitor(documentSvc, logger)
-
 	itemSvc := application.NewItemService(application.ItemServiceDeps{Repo: store, Workspaces: store, Logger: logger})
 	workspaceSvc := application.NewWorkspaceService(application.WorkspaceServiceDeps{Accounts: store, Workspaces: store, Users: store, Logger: logger})
 	userSvc := application.NewUserService(application.UserServiceDeps{Users: store, Accounts: store, Billing: billingSvc, Logger: logger})
@@ -139,6 +135,7 @@ func NewApplication(ctx context.Context, cfg config.API, logger *slog.Logger, nr
 		mux.Handle("POST /dev/seed-workspace", handler.NewDevSeedHTTPHandler(devSeedSvc, true))
 	}
 	mux.HandleFunc("GET /health", healthHandler(store, cfg.ReadinessKey, cfg.ReadinessMonitorKey))
+	registerMaintenanceSweep(mux, cfg, documentSvc, logger)
 
 	var h http.Handler = mux
 	h = apimiddleware.WithAuth(authenticator, logger, h)
@@ -168,49 +165,37 @@ func newWorkerDispatcher(ctx context.Context, cfg config.API, logger *slog.Logge
 	return dispatcher, dispatcher.Close, nil
 }
 
-func startAutoResume(documentSvc *application.DocumentService, logger *slog.Logger) {
-	go func() {
-		time.Sleep(15 * time.Second)
-		resumeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-		defer cancel()
-		resumed, err := documentSvc.AutoResumeFailedJobs(resumeCtx)
-		if err != nil {
-			logger.Error("job.auto_resume_scan_failed", "error", err.Error())
-			return
-		}
-		if resumed > 0 {
-			logger.Info("job.auto_resume_completed", "resumed", resumed)
-		}
-	}()
-}
-
-// stuckJobScanInterval is how often the stuck-job sweep runs. Re-emitting the
-// same job_id every interval is fine: the NR alert uses uniqueCount(job_id), so
-// repeats within the window collapse to one and running on several API
-// instances does not inflate the count.
-const stuckJobScanInterval = 5 * time.Minute
-
-// startStuckJobMonitor periodically sweeps for jobs wedged in QUEUED/RUNNING and
-// emits JobStuck events for New Relic to alert on. These never surface as
-// JobFailed, so this sweep is the only signal that a job silently stopped
-// progressing.
-func startStuckJobMonitor(documentSvc *application.DocumentService, logger *slog.Logger) {
-	go func() {
-		ticker := time.NewTicker(stuckJobScanInterval)
-		defer ticker.Stop()
-		for range ticker.C {
-			scanCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			stuck, err := documentSvc.ReportStuckJobs(scanCtx)
-			cancel()
-			if err != nil {
-				logger.Error("job.stuck_scan_failed", "error", err.Error())
-				continue
-			}
-			if stuck > 0 {
-				logger.Warn("job.stuck_scan_found", "count", stuck)
-			}
-		}
-	}()
+// registerMaintenanceSweep mounts the Cloud Scheduler-driven housekeeping route
+// (auto-resume of failed jobs + the stuck-job sweep that feeds the New Relic
+// JobStuck alert). Both used to be in-process goroutines, which only works when
+// Cloud Run keeps CPU allocated outside requests — i.e. when you pay for an
+// always-on instance. Driving them from Cloud Scheduler lets the service run
+// with cpu_idle=true and scale to zero between sweeps.
+//
+// Re-emitting the same job_id on every sweep is fine: the NR alert uses
+// uniqueCount(job_id), so repeats within the window collapse to one.
+//
+// The route is only mounted when the scheduler identity is configured, so local
+// and test runs (and any environment that has not been applied yet) expose no
+// unauthenticated surface. It stays outside the Firebase auth middleware —
+// see isAuthExempt — because it carries a Google OIDC token instead.
+func registerMaintenanceSweep(mux *http.ServeMux, cfg config.API, documentSvc *application.DocumentService, logger *slog.Logger) {
+	// Unset is the normal state locally and in tests, so this is not a warning.
+	// A half-configured deployment is, and falls through to the error below.
+	if strings.TrimSpace(cfg.Maintenance.SchedulerServiceAccountsCSV) == "" {
+		logger.Info("maintenance.sweep_disabled", "reason", "SYNTHIFY_MAINTENANCE_SCHEDULER_SERVICE_ACCOUNTS is empty")
+		return
+	}
+	schedulerAuth, err := apiauth.NewSchedulerAuthenticator(apiauth.SchedulerAuthenticatorConfig{
+		Audience:                  cfg.Maintenance.OIDCAudience,
+		AllowedServiceAccountsCSV: cfg.Maintenance.SchedulerServiceAccountsCSV,
+	})
+	if err != nil {
+		logger.Error("maintenance.sweep_disabled", "error", err.Error())
+		return
+	}
+	mux.Handle(apimiddleware.MaintenanceSweepPath, handler.NewMaintenanceHTTPHandler(documentSvc, schedulerAuth, logger))
+	logger.Info("maintenance.sweep_enabled", "path", apimiddleware.MaintenanceSweepPath)
 }
 
 type readinessChecker interface {

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -26,6 +26,19 @@ type API struct {
 	Stripe                   Stripe
 	Billing                  Billing
 	NewRelic                 NewRelic
+	Maintenance              Maintenance
+}
+
+// Maintenance identifies the Cloud Scheduler job allowed to drive the periodic
+// housekeeping sweep. Both fields must be set for the endpoint to be mounted;
+// an unset allowlist disables it rather than opening it up.
+type Maintenance struct {
+	// OIDCAudience the scheduler's token must carry. Terraform sets it to the
+	// API's own Cloud Run URL.
+	OIDCAudience string
+	// SchedulerServiceAccountsCSV are the caller identities permitted to invoke
+	// the sweep.
+	SchedulerServiceAccountsCSV string
 }
 
 // WorkerDispatch controls how the API hands jobs to the worker. When
@@ -129,6 +142,10 @@ func LoadAPI() API {
 		NewRelic: NewRelic{
 			AppName:    get("NEW_RELIC_APP_NAME", defaultNewRelicAppName("synthify-api")),
 			LicenseKey: os.Getenv("NEW_RELIC_LICENSE_KEY"),
+		},
+		Maintenance: Maintenance{
+			OIDCAudience:                os.Getenv("SYNTHIFY_MAINTENANCE_OIDC_AUDIENCE"),
+			SchedulerServiceAccountsCSV: os.Getenv("SYNTHIFY_MAINTENANCE_SCHEDULER_SERVICE_ACCOUNTS"),
 		},
 	}
 }

--- a/apps/api/internal/handler/maintenance.go
+++ b/apps/api/internal/handler/maintenance.go
@@ -1,0 +1,92 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	apiauth "github.com/synthify/backend/apps/api/internal/auth"
+)
+
+// MaintenanceSweeper is the periodic housekeeping the API used to run from
+// in-process goroutines. Cloud Run bills always-allocated CPU for that (and with
+// min-instances=0 the instance is often not even alive when the timer fires), so
+// the sweeps are driven by Cloud Scheduler through this endpoint instead.
+type MaintenanceSweeper interface {
+	AutoResumeFailedJobs(ctx context.Context) (int, error)
+	ReportStuckJobs(ctx context.Context) (int, error)
+}
+
+// MaintenanceAuthenticator authenticates the scheduler's OIDC token.
+type MaintenanceAuthenticator interface {
+	Authenticate(ctx context.Context, authorizationHeader string) (string, error)
+}
+
+type MaintenanceHTTPHandler struct {
+	sweeper MaintenanceSweeper
+	auth    MaintenanceAuthenticator
+	logger  *slog.Logger
+}
+
+func NewMaintenanceHTTPHandler(sweeper MaintenanceSweeper, auth MaintenanceAuthenticator, logger *slog.Logger) *MaintenanceHTTPHandler {
+	return &MaintenanceHTTPHandler{sweeper: sweeper, auth: auth, logger: logger}
+}
+
+type maintenanceSweepResult struct {
+	Resumed int `json:"resumed"`
+	Stuck   int `json:"stuck"`
+}
+
+func (h *MaintenanceHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	caller, err := h.auth.Authenticate(r.Context(), r.Header.Get("Authorization"))
+	if err != nil {
+		h.logger.Warn("maintenance.auth_failed", "error", err.Error())
+		if errors.Is(err, apiauth.ErrPermissionDenied) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Both sweeps run on the request context: Cloud Run cancels it at the
+	// service request timeout, which is the real budget here. The scheduler's
+	// attempt deadline is set to the same value so a run is never abandoned
+	// server-side while the client still waits.
+	ctx := r.Context()
+
+	resumed, err := h.sweeper.AutoResumeFailedJobs(ctx)
+	if err != nil {
+		h.logger.Error("job.auto_resume_scan_failed", "error", err.Error())
+		http.Error(w, "auto resume sweep failed", http.StatusInternalServerError)
+		return
+	}
+
+	stuck, err := h.sweeper.ReportStuckJobs(ctx)
+	if err != nil {
+		h.logger.Error("job.stuck_scan_failed", "error", err.Error())
+		http.Error(w, "stuck job sweep failed", http.StatusInternalServerError)
+		return
+	}
+
+	if resumed > 0 {
+		h.logger.Info("job.auto_resume_completed", "resumed", resumed)
+	}
+	if stuck > 0 {
+		h.logger.Warn("job.stuck_scan_found", "count", stuck)
+	}
+	h.logger.Info("maintenance.sweep_completed", "caller", caller, "resumed", resumed, "stuck", stuck)
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(maintenanceSweepResult{Resumed: resumed, Stuck: stuck}); err != nil {
+		h.logger.Error("maintenance.encode_failed", "error", err.Error())
+	}
+}

--- a/apps/api/internal/handler/maintenance_test.go
+++ b/apps/api/internal/handler/maintenance_test.go
@@ -1,0 +1,139 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apiauth "github.com/synthify/backend/apps/api/internal/auth"
+)
+
+type fakeSweeper struct {
+	resumed     int
+	stuck       int
+	resumeErr   error
+	stuckErr    error
+	resumeCalls int
+	stuckCalls  int
+}
+
+func (f *fakeSweeper) AutoResumeFailedJobs(context.Context) (int, error) {
+	f.resumeCalls++
+	return f.resumed, f.resumeErr
+}
+
+func (f *fakeSweeper) ReportStuckJobs(context.Context) (int, error) {
+	f.stuckCalls++
+	return f.stuck, f.stuckErr
+}
+
+type fakeMaintenanceAuth struct {
+	caller string
+	err    error
+}
+
+func (f fakeMaintenanceAuth) Authenticate(context.Context, string) (string, error) {
+	return f.caller, f.err
+}
+
+func newMaintenanceHandler(sweeper MaintenanceSweeper, auth MaintenanceAuthenticator) *MaintenanceHTTPHandler {
+	return NewMaintenanceHTTPHandler(sweeper, auth, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func TestMaintenanceHandler_RunsBothSweepsAndReportsCounts(t *testing.T) {
+	sweeper := &fakeSweeper{resumed: 2, stuck: 3}
+	rec := httptest.NewRecorder()
+
+	newMaintenanceHandler(sweeper, fakeMaintenanceAuth{caller: "sched@example.iam.gserviceaccount.com"}).
+		ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/maintenance/sweep", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if sweeper.resumeCalls != 1 || sweeper.stuckCalls != 1 {
+		t.Fatalf("expected both sweeps to run once, got resume=%d stuck=%d", sweeper.resumeCalls, sweeper.stuckCalls)
+	}
+	var body maintenanceSweepResult
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Resumed != 2 || body.Stuck != 3 {
+		t.Fatalf("expected the sweep counts in the body, got %+v", body)
+	}
+}
+
+func TestMaintenanceHandler_RejectsUnauthenticatedBeforeSweeping(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		authErr  error
+		wantCode int
+	}{
+		{name: "unauthenticated", authErr: fmt.Errorf("%w: no token", apiauth.ErrUnauthenticated), wantCode: http.StatusUnauthorized},
+		{name: "not allowlisted", authErr: fmt.Errorf("%w: other caller", apiauth.ErrPermissionDenied), wantCode: http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sweeper := &fakeSweeper{}
+			rec := httptest.NewRecorder()
+
+			newMaintenanceHandler(sweeper, fakeMaintenanceAuth{err: tc.authErr}).
+				ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/maintenance/sweep", nil))
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("expected %d, got %d", tc.wantCode, rec.Code)
+			}
+			if sweeper.resumeCalls != 0 || sweeper.stuckCalls != 0 {
+				t.Fatal("a rejected request must not touch the database")
+			}
+		})
+	}
+}
+
+func TestMaintenanceHandler_RejectsNonPost(t *testing.T) {
+	sweeper := &fakeSweeper{}
+	rec := httptest.NewRecorder()
+
+	newMaintenanceHandler(sweeper, fakeMaintenanceAuth{caller: "sched@example.iam.gserviceaccount.com"}).
+		ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/internal/maintenance/sweep", nil))
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+	if sweeper.resumeCalls != 0 {
+		t.Fatal("GET must not run the sweep")
+	}
+}
+
+func TestMaintenanceHandler_ReportsSweepFailures(t *testing.T) {
+	t.Run("auto resume failure short-circuits the stuck sweep", func(t *testing.T) {
+		sweeper := &fakeSweeper{resumeErr: errors.New("db down")}
+		rec := httptest.NewRecorder()
+
+		newMaintenanceHandler(sweeper, fakeMaintenanceAuth{caller: "sched@example.iam.gserviceaccount.com"}).
+			ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/maintenance/sweep", nil))
+
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500 so Cloud Scheduler records the failure, got %d", rec.Code)
+		}
+		if sweeper.stuckCalls != 0 {
+			t.Fatal("expected the stuck sweep to be skipped after the first failure")
+		}
+	})
+
+	t.Run("stuck sweep failure", func(t *testing.T) {
+		sweeper := &fakeSweeper{stuckErr: errors.New("db down")}
+		rec := httptest.NewRecorder()
+
+		newMaintenanceHandler(sweeper, fakeMaintenanceAuth{caller: "sched@example.iam.gserviceaccount.com"}).
+			ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/maintenance/sweep", nil))
+
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500 so Cloud Scheduler records the failure, got %d", rec.Code)
+		}
+	})
+}

--- a/apps/api/internal/middleware/auth.go
+++ b/apps/api/internal/middleware/auth.go
@@ -60,12 +60,18 @@ func writeAuthError(w http.ResponseWriter, err error, unauthorizedMessage string
 	http.Error(w, unauthorizedMessage, http.StatusUnauthorized)
 }
 
+// MaintenanceSweepPath is the Cloud Scheduler-driven housekeeping endpoint. It
+// is exempt from the Firebase middleware because it authenticates a Google OIDC
+// token itself (see auth.SchedulerAuthenticator); the handler is only mounted
+// when that identity is configured.
+const MaintenanceSweepPath = "/internal/maintenance/sweep"
+
 func isAuthExempt(r *http.Request) bool {
 	if r.Method == http.MethodOptions {
 		return true
 	}
 	switch r.URL.Path {
-	case "/health", "/stripe/webhook":
+	case "/health", "/stripe/webhook", MaintenanceSweepPath:
 		return true
 	// 公開リンクの解決は無認証経路 (token のみで workspace を解決する)。
 	case "/synthify.app.v1.WorkspaceService/ResolveShareLink":

--- a/docs/architecture/environment-variables.md
+++ b/docs/architecture/environment-variables.md
@@ -35,6 +35,10 @@
 | `eval_image` | LLM eval Cloud Run Job の container image | CD が `-var` で SHA tag image を渡す |
 | `eval_schedule` | LLM eval Cloud Run Job を起動する cron | `0 4 * * *` |
 | `eval_time_zone` | eval Scheduler の timezone | `Asia/Tokyo` |
+| `maintenance_schedule` | API の定期 sweep (job auto-resume / stuck job 検知) を起動する cron | `*/5 * * * *`。New Relic の `JobStuck` アラートが 5 分窓を前提にしているので、変えるなら `stuck_jobs` condition の `aggregation_window` も合わせる |
+| `maintenance_time_zone` | maintenance Scheduler の timezone | `Asia/Tokyo` |
+| `SYNTHIFY_MAINTENANCE_OIDC_AUDIENCE` | sweep 用 OIDC token の audience | Terraform が `services/api` の locals で生成し、Scheduler 側と同じ値を注入する。手で設定するものではない |
+| `SYNTHIFY_MAINTENANCE_SCHEDULER_SERVICE_ACCOUNTS` | sweep を叩ける呼び出し元 SA (カンマ区切り) | Terraform が `synthify-maint-sched-<env>` を注入する。**空だと API は sweep endpoint を mount しない** (fail closed) ので、sweep が止まったらまずここを見る |
 | `CORS_ALLOWED_ORIGINS` | フロントエンドの URL | `https://synthify.keyhole.work` |
 | `STRIPE_PRO_PRICE_ID_JPY` | JPY 建て Stripe 価格 ID（カンマ区切りで複数可） | `price_...` |
 | `STRIPE_PRO_PRICE_ID_USD` | USD 建て Stripe 価格 ID（カンマ区切りで複数可） | `price_...` |

--- a/terraform/environments/main.tf
+++ b/terraform/environments/main.tf
@@ -101,6 +101,10 @@ module "api" {
   allowed_user_emails               = var.allowed_user_emails
   log_llm_payload                   = var.log_llm_payload
   deletion_protection               = local.deletion_protection
+
+  maintenance_scheduler_service_account_email = module.bootstrap.maintenance_scheduler_service_account_email
+  maintenance_schedule                        = var.maintenance_schedule
+  maintenance_time_zone                       = var.maintenance_time_zone
 }
 
 module "monitor" {

--- a/terraform/environments/variables.tf
+++ b/terraform/environments/variables.tf
@@ -84,6 +84,17 @@ variable "eval_time_zone" {
   default = "Asia/Tokyo"
 }
 
+variable "maintenance_schedule" {
+  description = "Cron expression for the API job auto-resume / stuck-job sweep."
+  type        = string
+  default     = "*/5 * * * *"
+}
+
+variable "maintenance_time_zone" {
+  type    = string
+  default = "Asia/Tokyo"
+}
+
 variable "stripe_pro_price_id" {
   type    = string
   default = ""

--- a/terraform/services/api/main.tf
+++ b/terraform/services/api/main.tf
@@ -1,3 +1,12 @@
+locals {
+  # OIDC audience for the maintenance sweep. Deliberately a synthetic constant
+  # rather than module.service.uri: feeding the service's own URL back into its
+  # env_vars would be a dependency cycle. Cloud Scheduler mints the token with
+  # whatever audience it is given, and the API compares it verbatim, so the only
+  # requirement is that both sides agree.
+  maintenance_oidc_audience = "https://${var.name}/internal/maintenance/sweep"
+}
+
 module "service" {
   source = "../../modules/cloud_run_service"
 
@@ -8,6 +17,11 @@ module "service" {
   service_account_email = var.service_account_email
   allow_unauthenticated = true
   deletion_protection   = var.deletion_protection
+
+  # One number drives both the Cloud Run hard cancel and the maintenance
+  # scheduler's attempt deadline, so a retry can never overlap a sweep that is
+  # still running.
+  timeout = "${var.request_timeout_seconds}s"
 
   # PORT is a Cloud Run reserved env var: it is injected automatically from
   # the container port (cloud_run_service container_port, default 8080) and
@@ -60,6 +74,13 @@ module "service" {
     # Empty => no restriction (prod default).
     SYNTHIFY_ALLOWED_USER_EMAILS = var.allowed_user_emails
     LOG_LLM_PAYLOAD              = var.log_llm_payload
+
+    # Cloud Scheduler-driven housekeeping (auto-resume + stuck-job sweep). Both
+    # must be set or the API leaves the endpoint unmounted; it never falls back
+    # to an open route. The API is allow_unauthenticated=true, so run.invoker
+    # cannot gate this and the OIDC token is verified in-process instead.
+    SYNTHIFY_MAINTENANCE_OIDC_AUDIENCE              = local.maintenance_oidc_audience
+    SYNTHIFY_MAINTENANCE_SCHEDULER_SERVICE_ACCOUNTS = var.maintenance_scheduler_service_account_email
   }
 
   sensitive_env_vars = {
@@ -96,4 +117,41 @@ module "service" {
       secret = var.secret_ids["internal-worker-token"]
     },
   ]
+}
+
+# Periodic housekeeping that used to run as in-process goroutines in the API
+# (auto-resume of failed jobs, and the stuck-job sweep that feeds the New Relic
+# JobStuck alert). Timers inside the container only fire when Cloud Run keeps CPU
+# allocated between requests — i.e. when the service is billed as always-on — and
+# with min-instances=0 the instance is frequently not alive at all. Cloud
+# Scheduler drives them instead, so the service can run cpu_idle=true and scale
+# to zero.
+resource "google_cloud_scheduler_job" "maintenance_sweep" {
+  project     = var.project_id
+  region      = var.region
+  name        = "${var.name}-maintenance-sweep"
+  description = "Runs the Synthify API job auto-resume and stuck-job sweeps."
+  schedule    = var.maintenance_schedule
+  time_zone   = var.maintenance_time_zone
+
+  # Matches the Cloud Run request timeout: a longer deadline would let Scheduler
+  # give up while the sweep is still running, and a retry would then overlap it.
+  attempt_deadline = "${var.request_timeout_seconds}s"
+
+  retry_config {
+    # One retry covers a cold start or a blip. Beyond that the next scheduled
+    # run is the retry — the sweeps are idempotent, so nothing is lost by
+    # waiting, and hammering a struggling database helps no one.
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "${module.service.uri}/internal/maintenance/sweep"
+
+    oidc_token {
+      service_account_email = var.maintenance_scheduler_service_account_email
+      audience              = local.maintenance_oidc_audience
+    }
+  }
 }

--- a/terraform/services/api/variables.tf
+++ b/terraform/services/api/variables.tf
@@ -174,3 +174,25 @@ variable "deletion_protection" {
   type        = bool
   default     = true
 }
+
+variable "maintenance_scheduler_service_account_email" {
+  description = "Identity Cloud Scheduler uses for the maintenance sweep; the API only accepts OIDC tokens from this address."
+  type        = string
+}
+
+variable "maintenance_schedule" {
+  description = "Cron expression for the job auto-resume / stuck-job sweep. Matches the 5-minute cadence the in-process ticker used, which the New Relic JobStuck alert window assumes."
+  type        = string
+  default     = "*/5 * * * *"
+}
+
+variable "maintenance_time_zone" {
+  type    = string
+  default = "Asia/Tokyo"
+}
+
+variable "request_timeout_seconds" {
+  description = "Cloud Run request timeout. Also the maintenance scheduler's attempt deadline, so the two cannot drift."
+  type        = number
+  default     = 300
+}

--- a/terraform/services/bootstrap/main.tf
+++ b/terraform/services/bootstrap/main.tf
@@ -42,6 +42,7 @@ locals {
     eval_scheduler = module.platform.eval_scheduler_service_account_email
     api            = module.platform.api_service_account_email
     monitor        = module.platform.monitor_service_account_email
+    maint_schedule = module.platform.maintenance_scheduler_service_account_email
   }
 }
 

--- a/terraform/services/bootstrap/outputs.tf
+++ b/terraform/services/bootstrap/outputs.tf
@@ -25,6 +25,10 @@ output "eval_scheduler_service_account_email" {
   value = module.platform.eval_scheduler_service_account_email
 }
 
+output "maintenance_scheduler_service_account_email" {
+  value = module.platform.maintenance_scheduler_service_account_email
+}
+
 output "monitor_service_account_email" {
   value = module.platform.monitor_service_account_email
 }

--- a/terraform/services/monitoring/job_conditions.tf
+++ b/terraform/services/monitoring/job_conditions.tf
@@ -27,9 +27,11 @@ resource "newrelic_nrql_alert_condition" "job_failure_rate" {
   aggregation_window = 300
 }
 
-# Stuck job spike: the API periodically sweeps for jobs wedged in QUEUED/RUNNING
-# past a grace period and emits a JobStuck event per job_id. uniqueCount(job_id)
-# dedups the periodic re-emissions and multiple API instances.
+# Stuck job spike: Cloud Scheduler calls the API's maintenance sweep every 5
+# minutes (services/api google_cloud_scheduler_job.maintenance_sweep), which
+# reports jobs wedged in QUEUED/RUNNING past a grace period and emits a JobStuck
+# event per job_id. uniqueCount(job_id) dedups the periodic re-emissions, so the
+# 300s aggregation window below assumes that same 5-minute cadence.
 resource "newrelic_nrql_alert_condition" "stuck_jobs" {
   account_id                   = var.new_relic_account_id
   policy_id                    = newrelic_alert_policy.critical.id

--- a/terraform/services/platform/main.tf
+++ b/terraform/services/platform/main.tf
@@ -60,6 +60,22 @@ module "eval_scheduler_service_account" {
   depends_on = [google_project_service.required]
 }
 
+# Identity Cloud Scheduler uses to drive the API's periodic housekeeping sweep
+# (auto-resume + stuck-job detection). The API service is publicly invocable, so
+# unlike the eval job this is not gated by run.invoker: the API validates the
+# OIDC token and checks the caller email against this address.
+module "maintenance_scheduler_service_account" {
+  source = "../../modules/service_account"
+
+  project_id = var.project_id
+  # Kept short on purpose: account_id maxes out at 30 chars and
+  # "synthify-maintenance-scheduler-<env>" overflows it.
+  account_id   = "synthify-maint-sched-${var.environment}"
+  display_name = "Synthify Maintenance Scheduler (${var.environment})"
+
+  depends_on = [google_project_service.required]
+}
+
 module "monitor_service_account" {
   source = "../../modules/service_account"
 

--- a/terraform/services/platform/outputs.tf
+++ b/terraform/services/platform/outputs.tf
@@ -22,6 +22,10 @@ output "eval_scheduler_service_account_email" {
   value = module.eval_scheduler_service_account.email
 }
 
+output "maintenance_scheduler_service_account_email" {
+  value = module.maintenance_scheduler_service_account.email
+}
+
 output "monitor_service_account_email" {
   value = module.monitor_service_account.email
 }


### PR DESCRIPTION
## 背景

API は 2 つの sweep を in-process goroutine で回していました。

- 起動 15 秒後に 1 回だけ走る失敗ジョブの auto-resume
- 5 分間隔の stuck-job スキャン（New Relic の `JobStuck` アラートの供給元）

どちらも min-instances=0 の Cloud Run では信頼できません。タイマーはインスタンスが偶然生きているときにしか発火せず、リクエスト外では常時割り当て課金にしない限り CPU が絞られるためです。

## 変更

両方を `POST /internal/maintenance/sweep` に移し、Cloud Scheduler から ticker と同じ 5 分間隔で叩きます（`JobStuck` アラートの 300s aggregation window がこの間隔を前提にしているため揃えています）。

**認証**: API は `allow_unauthenticated=true` でデプロイされているため、worker や eval job のように `run.invoker` で守れません。ハンドラが Cloud Scheduler の Google OIDC トークンをプロセス内で検証し、呼び出し元を許可 SA（`synthify-maint-sched-<env>`）と突き合わせます。audience と許可リストの両方が設定されていなければ **ルート自体を mount しません**。開いたエンドポイントに degrade することはなく、ローカルやテストでは単に存在しません。

**OIDC audience** はサービス URL ではなく合成定数にしています。`module.service.uri` を同じモジュールの `env_vars` に戻すと循環参照になるためです。Scheduler は与えられた audience でトークンを発行し、API はそれをそのまま比較するので、両者が一致していれば十分です。

## 主な変更ファイル

| ファイル | 内容 |
| --- | --- |
| `apps/api/internal/auth/scheduler.go` | OIDC トークン検証と SA 許可リスト |
| `apps/api/internal/handler/maintenance.go` | sweep エンドポイント |
| `apps/api/internal/bootstrap/application.go` | goroutine 削除、ルート登録 |
| `terraform/services/api/main.tf` | `google_cloud_scheduler_job` |
| `terraform/services/platform/main.tf` | 専用 SA |

## 検証

- `go build ./...` / `go vet ./apps/api/...` / `go test ./apps/api/...` すべて green
- 新規テスト: OIDC 認証（allowlist / audience / fail-closed / 未検証 email の拒否）、handler（401 / 403 / 405 / 500、拒否時に DB を触らないこと）
- `terraform fmt -recursive` clean
- `terraform validate` は未実行（実行環境のネットワークポリシーが `registry.terraform.io` を 403 で遮断しており provider を取得できませんでした）

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_