### PR TITLE
ci: probe readiness every 15 minutes instead of every 5

### DIFF
--- a/.github/workflows/readiness-monitor.yml
+++ b/.github/workflows/readiness-monitor.yml
@@ -2,8 +2,14 @@ name: Readiness Monitor
 
 on:
   schedule:
-    # Every 5 minutes.
-    - cron: "*/5 * * * *"
+    # Every 15 minutes, across stage and prod. At 5 minutes this probe was
+    # effectively a keep-alive: Cloud Run holds an idle instance for roughly 15
+    # minutes, so it kept one running around the clock in both environments.
+    # This is a liveness signal for a sustained outage, not a latency SLO, and
+    # it does not need to pay cold-start CPU 288 times a day per environment to
+    # be one. Two consecutive misses (the retry below) still surface an outage
+    # inside half an hour.
+    - cron: "*/15 * * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 変更

readiness monitor の cron を 5 分間隔から 15 分間隔にします。

5 分間隔だと、この workflow は事実上 Cloud Run サービスの keep-alive として機能していました。Cloud Run はアイドルインスタンスを約 15 分保持するため、stage と prod の両方でインスタンスが 24 時間動き続けていました。

これは持続的な障害を検知するための liveness チェックであって、レイテンシ SLO ではありません。15 分間隔でも既存の 2 段リトライで 30 分以内に障害を検知できますし、そのために 1 環境あたり 1 日 288 回のコールドスタート CPU を払う必要はありません。

## 補足

この PR は単独で成立しますが、コスト面での本命は #25（`cpu_idle` の明示）です。あちらが入れば常時割り当て課金は解消されるので、こちらは「不要な起床を減らす」以上の意味は持ちません。順序の依存はありません。

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_