### PR TITLE
fix(ci): install Playwright browsers with the Playwright the tests actually use

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -17,7 +17,10 @@ jobs:
         with:
           bun-version: 1.3.13
       - run: bun install --frozen-lockfile
-      - run: bunx playwright install --with-deps chromium
+      # From apps/web so the browser matches the test runner's Playwright; see
+      # the note in web.yml.
+      - working-directory: apps/web
+        run: bun run playwright:install
       - name: Run explicitly tagged external checks
         working-directory: apps/web
         env:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -134,8 +134,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Installed from apps/web, not the repo root: the root package.json is a
+      # bun workspace root with no Playwright dependency, so `bunx playwright`
+      # there resolves nothing locally and silently downloads an unpinned
+      # version from the registry. That installs a browser build for a
+      # different Playwright than the one the tests run, and the tests then
+      # fail with "Executable doesn't exist". `bun run` uses the workspace's
+      # own node_modules/.bin, so the browser always matches the test runner.
       - name: Install Chromium
-        run: bunx playwright install --with-deps chromium
+        working-directory: apps/web
+        run: bun run playwright:install
 
       # Prebuilt API/worker binaries (see the binaries job) that the compose
       # backend/worker exec instead of running `go build` at boot.
@@ -207,8 +215,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # As in the e2e job: install with the workspace's own Playwright. This one
+      # uses playwright-core, which is what the screenshot script imports.
       - name: Install Chromium
-        run: bunx playwright install --with-deps chromium
+        working-directory: apps/monitor/ui
+        run: bun run playwright:install
 
       - name: Capture monitor screenshots
         working-directory: apps/monitor/ui

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Synthify は、アップロードしたドキュメントから知識ツリー�
 
 ```bash
 cd apps/web
-bunx playwright install chromium
+bun run playwright:install
 bun run e2e
 ```
 

--- a/apps/monitor/ui/package.json
+++ b/apps/monitor/ui/package.json
@@ -10,7 +10,8 @@
     "build": "next build",
     "start": "next start --hostname 0.0.0.0 --port 5174",
     "test": "bun test src",
-    "screenshots": "node scripts/screenshots/run.mjs"
+    "screenshots": "node scripts/screenshots/run.mjs",
+    "playwright:install": "playwright-core install --with-deps chromium"
   },
   "dependencies": {
     "firebase": "^12.12.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "e2e:repeat5": "playwright test --project=chromium --repeat-each=5",
     "e2e:nightly": "playwright test --project=chromium --grep @nightly",
     "e2e:report": "playwright show-report",
+    "playwright:install": "playwright install --with-deps chromium",
     "generate:firestore-types": "node ../../scripts/generate-firestore-types.mjs",
     "seed:jobs": "node ./scripts/seed-firestore-jobs.mjs"
   },


### PR DESCRIPTION
## 症状

現在、**どの PR でも** `e2e (1)` / `e2e (2)` / `monitor-screenshots` の 3 ジョブが同じエラーで落ちます。

```
browserType.launch: Executable doesn't exist at
  /home/runner/.cache/ms-playwright/chromium_headless_shell-1228/...
Looks like Playwright was just installed or updated.
Please run: npx playwright install
```

e2e は `auth.setup.ts` の browser 起動時点で落ちるため、テストは 1 件も実行されません（`11 did not run`）。

## 原因

browser install ステップが、**テストが使うのとは別バージョンの Playwright** で実行されています。

```yaml
- name: Install Chromium
  run: bunx playwright install --with-deps chromium   # ← working-directory 指定なし = リポジトリルート
```

ルートの `package.json` は bun workspace のルートで、Playwright 系の依存を持たず `node_modules/.bin` 自体が存在しません。そのため `bunx` はローカルの CLI を解決できず、**レジストリから未固定のバージョンを落としてきます**。

手元で確認した実際の解決結果:

| 実行場所 | `bunx playwright --version` |
|---|---|
| リポジトリルート（= CI と同じ） | **1.56.1** |
| `apps/web`（= テストが動く場所） | 1.61.1 |

`@playwright/test@1.61.1` が要求する browser build は **1228**。install 側は別バージョンとして動くので 1228 は入らず、テストが起動時に見つけられない、という状態です。

### なぜ「今」壊れたのか

`bunx` が取るバージョンが**実行時にレジストリから解決される**ためで、リポジトリ側の変更は一切不要でした。main の最後の実行は 7/24 で green。それ以降 main は変わっていませんが、以後に出された PR はすべて同じ形で落ちます。

## 修正

各ジョブが**自分の workspace の Playwright** で install するようにしました。package.json の script 経由にすることで、binary はその workspace の `node_modules/.bin` から解決され、**レジストリへのフォールバックが起こり得なくなります**。

| workspace | script |
|---|---|
| `apps/web` | `playwright install --with-deps chromium`（`@playwright/test`） |
| `apps/monitor/ui` | `playwright-core install --with-deps chromium`（screenshot script が import しているもの） |

e2e と monitor-screenshots は**別ジョブ = 別ランナー**で browser cache を共有していないため、どちらにせよ各自 install が必要です。workspace ごとに install する形にしておけば、将来 2 つが別バージョンに分かれても互いを壊しません。

`e2e-nightly.yml` も同じルート実行だったので併せて修正。README のセットアップ手順も script を指すようにして、やり方を 1 つに統一しました。

## 検証

`bun run playwright:install` を両 workspace で実行し、いずれも 1.61.1 が解決され、**CI が「無い」と言っていた build を要求する**ことを確認:

```
$ playwright install --with-deps chromium          # apps/web
Downloading Chrome for Testing 149.0.7827.55 (playwright chromium v1228) ...

$ playwright-core install --with-deps chromium     # apps/monitor/ui
Downloading Chrome for Testing 149.0.7827.55 (playwright chromium v1228) ...
```

比較のため、修正前のルート実行は 1.56.1 として動き、v1228 を要求しません。

**ダウンロード自体はこの作業環境では完走できていません**（`cdn.playwright.dev` が egress policy で 403）。したがって「正しい build を要求するところまで」は検証済み、「実際に落とし切って起動するところ」は未検証です。GitHub runner 側では到達できるはずなので、この PR の CI が green になれば最終確認になります。

YAML の構文は両ファイルとも parse 確認済みです。

## 補足

この不具合は #23 / #24 のどちらとも無関係で、両 PR はこの修正が入るまで CI を green にできません（両 PR とも `checks` / `build` / `binaries` / `terraform` は success で、落ちているのはこの 3 ジョブだけです）。この PR が先にマージされると良さそうです。

---
_Generated by [Claude Code](https://claude.ai/code/session_017MBzVjZkFQW3C8SNucrFij)_