### PR TITLE
docs(terraform): document the monitor DSN and the secrets CD requires

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -83,20 +83,60 @@ init→apply→placeholder secret→2回目 apply を自動化する。
 
 `synthify-<key>` という命名。stage と prod は別 GCP project の Secret Manager に同じ名前で作成する。
 
-| Key | 内容 | 必須 |
+| Key | 内容 | 用途 |
 |---|---|---|
-| `database-dsn` | CockroachDB Serverless の接続文字列 (`postgresql://...`) | ✅ |
-| `internal-worker-token` | worker → api 内部通信トークン (適当なランダム文字列) | ✅ |
-| `stripe-secret-key` | Stripe Secret Key (`sk_live_...`) | Stripe 使う時 |
-| `stripe-webhook-secret` | Stripe Webhook Signing Secret | Stripe 使う時 |
-| `new-relic-license-key` | New Relic Ingest License Key | NR 使う時 |
+| `database-dsn` | CockroachDB Serverless の接続文字列 (`postgresql://...`)。admin 権限のユーザ (migration もこれで流す) | api / worker |
+| `monitor-database-dsn` | 上と**同じ DB** への接続文字列。ただしユーザは read-only の `monitor` ロール (下記) | monitor |
+| `internal-worker-token` | worker → api 内部通信トークン (適当なランダム文字列) | api / worker |
+| `gemini-api-key` | Gemini API キー | worker / eval |
+| `stripe-secret-key` | Stripe Secret Key (`sk_live_...`) | api |
+| `stripe-webhook-secret` | Stripe Webhook Signing Secret | api |
+| `new-relic-license-key` | New Relic Ingest License Key | api / worker |
 
-未使用の secret も Cloud Run が `latest` を参照するので**最低 1 version は必要**。
-未使用なら placeholder 文字列を入れておく:
+Cloud Run が `latest` を参照するので、**この表の全部が最低 1 version 必要**。
+1 つでも version が無いと CD の `Verify all secrets have a version` が
+image の build にも migration にも進まずに落ちる (`deploy-backend.yml`)。
+実際に使わない連携があるなら placeholder を入れておく:
 
 ```bash
 printf 'unused' | gcloud secrets versions add synthify-stripe-secret-key --data-file=-
 ```
+
+ただし placeholder を入れてよいのは**本当に使っていない**ものだけ。値が空のまま
+Cloud Run が「起動には成功するが動かない」状態になるのが一番厄介な壊れ方で、
+過去に stage はこれで落ちている。
+
+### `monitor-database-dsn` の作り方
+
+monitor ダッシュボードは API を経由せず Postgres を直接読む。参照先は
+**api / worker と同じクラスタ・同じ database** で、違うのは接続ユーザだけ。
+DB レイヤで read-only に縛るため、専用の `monitor` ロールで接続する
+(`terraform/services/monitor/main.tf` の `MONITOR_DATABASE_URL`)。
+
+`monitor` ロール自体は migration `0014_monitor_role` が
+`CREATE ROLE IF NOT EXISTS monitor LOGIN` で作り、参照してよいテーブルと view にだけ
+`GRANT SELECT` する (eval 系は `0024_eval_views_grants`)。ただし
+**パスワードは migration では設定していない**ので、環境ごとに一度だけ手で入れる:
+
+```bash
+# 1. monitor ロールにパスワードを設定 (admin DSN = synthify-database-dsn で接続)
+#    パスワードは任意の強いランダム文字列
+psql "$ADMIN_DSN" -c "ALTER ROLE monitor WITH PASSWORD '<generated>'"
+
+# 2. その資格情報で DSN を組んで Secret に投入。
+#    ホスト / database 名 / sslmode は database-dsn と同じものを流用し、
+#    user と password だけ差し替える。
+printf 'postgresql://monitor:<generated>@<host>:<port>/<database>?sslmode=verify-full' \
+  | gcloud secrets versions add synthify-monitor-database-dsn \
+      --project <gcp-project> --data-file=-
+```
+
+stage と prod で別々に必要 (project は `synthify-stage-491705` /
+`synthify-491705`)。ローカルの compose では `monitor@127.0.0.1` に
+パスワード無しで繋ぐ既定値が入っているので、この手順は不要。
+
+投入後は push し直さなくても、Actions の `Deploy Backend` を
+`workflow_dispatch` で環境を選んで再実行すれば続きから流れる。
 
 ## 主要コマンド
 


### PR DESCRIPTION
## なぜ

stage / prod のデプロイが `Verify all secrets have a version` で停止する:

```
Refusing to deploy: 1 secret(s) unset: synthify-monitor-database-dsn
```

この secret がリポジトリのどこにも説明されていなかった。存在すること、何を入れるのか、そして **migration がやってくれない手作業が要ること** のどれも書かれていない。`terraform/README.md` の secret 表は monitor サービスより古く、`monitor-database-dsn` も `gemini-api-key` も載っていなかった。

## 変更内容

**secret 表を実態に合わせた** — CD がチェックする 7 つを全部列挙し、`必須` 列を `用途` に差し替えた。旧表記だと Stripe / New Relic が任意に読めるが、実際は `deploy-backend.yml` のゲートが「1 つでも version が無ければ image build にも migration にも進まず落とす」ので、全部に最低 1 version 必要。各行の対応サービスは terraform の `secret_env_vars` を実際に確認して埋めた（gemini → worker/eval、stripe → api、new relic → api/worker）。

**`monitor-database-dsn` の作り方を追記** — 自明でないのはこれだけなので節を立てた:

- 参照先は `database-dsn` と**同じクラスタ・同じ database**。違うのは接続ユーザだけ。新しく DB を用意する必要はない
- monitor は API を経由せず Postgres を直接読むので、アプリ層の認可ではなく DB レイヤの read-only `monitor` ロールで縛る設計（`terraform/services/monitor/main.tf` の `MONITOR_DATABASE_URL`）
- `0014_monitor_role` がロールを `CREATE ROLE IF NOT EXISTS monitor LOGIN` で作り、`0024_eval_views_grants` が eval 系の view に `GRANT SELECT` する。しかし**どの migration もパスワードを設定しない** — `ALTER ROLE monitor WITH PASSWORD` は環境ごとの手作業で、これを踏まないと DSN が組めない
- 投入後は push し直さず `workflow_dispatch` で再実行すれば続きから流れる、という復帰手順も併記

## 検証

ドキュメントのみで、コード変更なし。記載内容は以下を実地で確認した上で書いている:

- `synthify-monitor-database-dsn` が version 無しで stage / prod 両方のデプロイを止めた（run [30643671483](https://github.com/Keyhole-Koro/Synthify/actions/runs/30643671483) / [30643671410](https://github.com/Keyhole-Koro/Synthify/actions/runs/30643671410)）
- CD がチェックする secret 一覧は `deploy-backend.yml:113` の実際のループから転記
- 各 secret の消費先は `terraform/services/*/main.tf` を grep して確認
- `monitor` ロールにパスワードを設定する箇所がリポジトリに存在しないことを確認（`scripts/apply-db-migrations.sh` にも無し）
- ローカル compose がパスワード無しの `monitor@127.0.0.1` を既定にしていることを確認（`compose.yaml:197`）

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_