### PR TITLE
ci(deploy): refuse a terraform apply that destroys resources

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -86,6 +86,14 @@ jobs:
       # --- Pass 1: create just the platform layer (Artifact Registry,
       # APIs, service accounts, secrets) so we have a repo to push to.
       # Cloud Run services are NOT created here — they need the image.
+      #
+      # All three passes go through scripts/terraform-guarded-apply.sh instead
+      # of `terraform apply -auto-approve`: it plans first, refuses to apply a
+      # plan that destroys anything, and then applies that same plan. Pass 2 is
+      # untargeted, so deploying a branch whose config is older than the state
+      # would otherwise silently delete everything the branch does not know
+      # about. Replacements are still allowed; see the script for the escape
+      # hatch when a destroy is what you actually want.
       - name: Terraform apply (platform only)
         working-directory: ${{ env.TF_DIR }}
         run: |
@@ -94,7 +102,7 @@ jobs:
           # deployer IAM grant. All of it lives in module.bootstrap, so this
           # is a single -target. Adding an IAM binding to the module never
           # requires editing this workflow again.
-          terraform apply -auto-approve \
+          ../../scripts/terraform-guarded-apply.sh \
             -var-file=../tfvars/${ENVIRONMENT}.tfvars \
             -target=module.bootstrap
 
@@ -241,7 +249,6 @@ jobs:
           READINESS_MONITOR_KEY: ${{ secrets.READINESS_MONITOR_KEY }}
         run: |
           args=(
-            -auto-approve
             -var-file=../tfvars/${ENVIRONMENT}.tfvars
             -var="api_image=${{ steps.registry.outputs.api_image }}"
             -var="worker_image=${{ steps.registry.outputs.worker_image }}"
@@ -259,7 +266,7 @@ jobs:
           if [ -n "${ALLOWED_USER_EMAILS}" ]; then
             args+=(-var="allowed_user_emails=${ALLOWED_USER_EMAILS}")
           fi
-          terraform apply "${args[@]}"
+          ../../scripts/terraform-guarded-apply.sh "${args[@]}"
 
       # --- Pass 3: feed the API URL back so the worker can call it.
       - name: Terraform apply (wire api_base_url)
@@ -276,7 +283,6 @@ jobs:
         run: |
           API_URI="$(terraform output -raw api_uri)"
           args=(
-            -auto-approve
             -var-file=../tfvars/${ENVIRONMENT}.tfvars
             -var="api_image=${{ steps.registry.outputs.api_image }}"
             -var="worker_image=${{ steps.registry.outputs.worker_image }}"
@@ -295,7 +301,7 @@ jobs:
           if [ -n "${ALLOWED_USER_EMAILS}" ]; then
             args+=(-var="allowed_user_emails=${ALLOWED_USER_EMAILS}")
           fi
-          terraform apply "${args[@]}"
+          ../../scripts/terraform-guarded-apply.sh "${args[@]}"
 
       - name: Outputs
         working-directory: ${{ env.TF_DIR }}

--- a/scripts/terraform-guarded-apply.sh
+++ b/scripts/terraform-guarded-apply.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Plan, refuse to continue if the plan destroys anything, then apply the exact
+# plan that was inspected.
+#
+# Why this exists: the deploy pipeline applies without -target in Pass 2, so a
+# deploy from a branch whose Terraform config is older than what was last
+# applied to that environment silently proposes destroying every resource the
+# branch does not know about. The stage/prod branches are cherry-pick deploy
+# branches that drift behind main by design, and an environment can also be
+# applied out-of-band via workflow_dispatch from another ref — both leave the
+# state ahead of the config. -auto-approve means nothing stops it.
+#
+# Usage:
+#   scripts/terraform-guarded-apply.sh -var-file=../tfvars/stage.tfvars -var=...
+#
+# Pass the plan arguments only. Do NOT pass -auto-approve: the apply consumes a
+# saved plan file, which never prompts and rejects re-specified variables.
+#
+# Set ALLOW_DESTROY=true to proceed anyway, for the case where the destroy is
+# the intended change (a resource genuinely removed from config).
+set -euo pipefail
+
+plan_file="$(mktemp -t tfplan.XXXXXX)"
+plan_json="${plan_file}.json"
+trap 'rm -f "$plan_file" "$plan_json"' EXIT
+
+terraform plan -out="$plan_file" "$@"
+terraform show -json "$plan_file" >"$plan_json"
+
+# A pure destroy is exactly ["delete"]. A replace is ["delete","create"] or
+# ["create","delete"] and is deliberately allowed: that is how Terraform
+# updates an immutable field, it happens during ordinary deploys, and blocking
+# it would block them.
+mapfile -t destroys < <(
+  jq -r '
+    .resource_changes[]?
+    | select(.change.actions == ["delete"])
+    | .address
+  ' "$plan_json"
+)
+
+if [ ${#destroys[@]} -gt 0 ]; then
+  if [ "${ALLOW_DESTROY:-}" = "true" ]; then
+    echo "::warning::plan destroys ${#destroys[@]} resource(s); continuing because ALLOW_DESTROY=true"
+    printf '  %s\n' "${destroys[@]}"
+  else
+    echo "::error::Refusing to apply: the plan destroys ${#destroys[@]} resource(s)"
+    printf '::error::  %s\n' "${destroys[@]}"
+    cat >&2 <<'EOF'
+
+This usually means the checked-out config is older than the state — the branch
+being deployed does not contain something that was already applied to this
+environment. Sync the deploy branch with the config that produced the state
+rather than letting the apply remove the resources.
+
+If the destroy IS the intended change, re-run with ALLOW_DESTROY=true.
+EOF
+    exit 1
+  fi
+fi
+
+terraform apply "$plan_file"


### PR DESCRIPTION
## なぜ

Pass 2 は `-target` 無しの `terraform apply -auto-approve`。つまり **state にあって config に無いリソースを全部消す**。ログに plan が流れるだけで警告は無い。

このリポジトリでは仮定の話ではない。`stage` / `prod` は設計上 main から遅れる cherry-pick デプロイブランチで、さらに `workflow_dispatch` で別の ref から環境に apply することもできる。どちらも state が config より新しい状態を作る。

実際 7/12 に `main` から dispatch で stage に apply された結果、stage の state に newrelic リソースが入った。stage ブランチには monitoring module が無いので、**次の push デプロイはその環境のアラートポリシー / condition / notification workflow を全部削除するはずだった**。そうならなかったのは、同じドリフトで provider が stage の lock ファイルから漏れていて `terraform init` が先に落ちたからで、偶然であってガードではない。

## 変更内容

3 つの pass すべてを `scripts/terraform-guarded-apply.sh` 経由にした。動作は:

1. `terraform plan -out=<file>` でプランをファイルに保存
2. `terraform show -json` して `resource_changes` を検査
3. pure delete があればアドレスを列挙して**ステップを失敗させる**
4. 無ければ **検査したそのプランファイルを apply する**（plan と apply が食い違う余地を消す）

**replace は通す** — `["delete","create"]` は immutable フィールド更新の正常な形で、通常のデプロイで発生する。裸の `["delete"]` だけを destroy と判定する。

**エスケープハッチ** — 削除が意図した変更であれば `ALLOW_DESTROY=true` で続行できる（warning は出る）。エラーメッセージにもこの案内を入れてある。

## 検証

この環境に `terraform` バイナリが無いため、実プランでの検証はできていない。代わりに `terraform` をスタブして、スクリプトの制御フローを実際に流して確認した:

| ケース | 期待 | 結果 |
|---|---|---|
| pure delete 2 件 | apply せず exit 1 | ✅ アドレス2件を列挙して exit 1、apply 未実行 |
| pure delete + `ALLOW_DESTROY=true` | warning 出して apply | ✅ |
| delete 無し（create/update/no-op/replace 両順序） | apply | ✅ |

検出ロジックの切り分けもフィクスチャで確認済み: `["delete","create"]` と `["create","delete"]` は**検出されず**、`["delete"]` のみ検出。`resource_changes` が無い空プランでも落ちない。

その他:
- `bash -n` 構文チェック済み、実行ビット付与済み
- ワークフローの YAML パース確認済み
- `TF_DIR`（`terraform/environments`）から見た `../../scripts/...` の相対パスが解決することを確認
- CI 内に `terraform apply` の直呼びが残っていないことを grep で確認（残るヒットはコメントと echo のみ）

## 残っている穴

`scripts/manage-env.sh`（`make infra-*-up` の経路、65 行目と 95 行目）は依然 `-auto-approve` で apply していて、本 PR では覆っていない。あれは `terraform -chdir=` を使うのでガードに chdir パススルーを足す必要があり、この環境では terraform が無くて経路を検証できないため、別途に分けた。

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_