### PR TITLE
fix(monitor): copy the vendored web package into the image deps stage

### DIFF
--- a/apps/monitor/ui/Dockerfile
+++ b/apps/monitor/ui/Dockerfile
@@ -9,6 +9,12 @@ WORKDIR /repo
 COPY package.json bun.lock ./
 COPY apps/web/package.json apps/web/package.json
 COPY apps/monitor/ui/package.json apps/monitor/ui/package.json
+# apps/web declares "@keyhole-koro/paper-in-paper": "file:./vender/paper-in-paper"
+# (a submodule). monitor does not use it, but it shares the workspace lockfile,
+# so bun still has to link it — and a file: dependency cannot be linked from a
+# package.json alone. Without the directory here, the install fails with
+# "ENOENT: ... failed to link package: @keyhole-koro/paper-in-paper".
+COPY apps/web/vender/paper-in-paper apps/web/vender/paper-in-paper
 RUN bun install --frozen-lockfile
 
 # ---- builder: ソースを載せて monitor を standalone ビルド ----


### PR DESCRIPTION
## なぜ

stage / prod のデプロイが両方とも `Build and push images (parallel)` で失敗しています（[stage](https://github.com/Keyhole-Koro/Synthify/actions/runs/30681801781) / [prod](https://github.com/Keyhole-Koro/Synthify/actions/runs/30681806684)）。落ちているのは **monitor イメージだけ**で、api / worker / eval は同じ run 内で正常に build & push されています。

```
> [deps 6/6] RUN bun install --frozen-lockfile:
ENOENT: No such file or directory: failed to link package:
  @keyhole-koro/paper-in-paper@apps/web/vender/paper-in-paper (open)
Failed to install 1 package
```

deps ステージは lockfile と各ワークスペースの `package.json` だけを COPY します。レイヤキャッシュの観点では正しい形ですが、これだけでは足りません。`apps/web/package.json` が

```json
"@keyhole-koro/paper-in-paper": "file:./vender/paper-in-paper"
```

という **submodule へのローカルパス依存**を宣言しているためです。monitor はこのパッケージを import しませんが、bun workspace は lockfile を共有するので install 時にリンクは走り、`file:` 依存は package.json だけでは解決できません（実体ディレクトリが必要）。

monitor イメージがこのパイプラインでビルドされるのは今回が初めてだったため、これまで表面化していませんでした。

## 変更内容

deps ステージに実体を COPY する 1 行（と経緯のコメント）を追加しただけです。

## 検証

この環境に Docker が無いため**実ビルドでの確認はできていません**。確認できたのは以下まで:

- `.gitmodules` に `apps/web/vender/paper-in-paper` が submodule として定義されていること
- `apps/web/package.json:31` の `file:` 依存が、まさにそのパスを指していること
- CD が `actions/checkout` を `submodules: recursive` で実行しており、ビルドコンテキストに実体が入ること（失敗した run のログにも `Entering 'apps/web/vender/paper-in-paper'` が出ている）
- `.dockerignore` が このパスを除外していないこと（全パターンを突き合わせて確認）

## 補足

- deps レイヤのキャッシュが、この submodule の更新時にも無効化されるようになります。滅多に動かない vendored 依存なので許容と判断しました。回避するには「lockfile を共有するワークスペースメンバーを install 対象から外す」必要があり、得られるものの割に変更が大きくなります
- `.dockerignore` の `**/dist` により、vendored パッケージがビルド済み `dist/` を同梱していた場合それは入りません。monitor はこのパッケージを import しないので影響は無いはずですが、submodule の中身をこの環境で確認できていないため念のため記しておきます

## デプロイの現状

参考まで。この PR がマージされて再デプロイされるまで、両環境は**中途半端な状態**です:

| | stage | prod |
|---|---|---|
| DB マイグレーション 0021〜0024 | ✅ 適用済み | ✅ 適用済み |
| api / worker / eval イメージ | ✅ push 済み | ✅ push 済み |
| monitor イメージ | ❌ 失敗 | ❌ 失敗 |
| `Terraform apply (full)` 以降 | ⏭ skipped | ⏭ skipped |

DB は新スキーマ、Cloud Run は旧コードのままです。マイグレーションを先に流すのはワークフローの設計どおりなので当面は動くはずですが、早めに完走させたほうが安全です。

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_