### PR TITLE
fix(monitor): carry the workspace node_modules into the builder stage

### DIFF
--- a/apps/monitor/ui/Dockerfile
+++ b/apps/monitor/ui/Dockerfile
@@ -21,6 +21,11 @@ RUN bun install --frozen-lockfile
 FROM oven/bun:1.3.13-alpine AS builder
 WORKDIR /repo
 COPY --from=deps /repo/node_modules ./node_modules
+# bun installs a workspace member's own dependencies under that member, not at
+# the root: `next` and its bin symlink live in apps/monitor/ui/node_modules/.bin,
+# and the root node_modules/.bin does not carry them. Copying only the root tree
+# leaves `bun run build` with "next: not found" (exit 127).
+COPY --from=deps /repo/apps/monitor/ui/node_modules ./apps/monitor/ui/node_modules
 COPY . .
 
 # NEXT_PUBLIC_* はクライアントバンドルへビルド時に焼き込まれるので build-arg で渡す。


### PR DESCRIPTION
## なぜ

#31 で `bun install` は通るようになりました（`1275 packages installed`、リンク失敗なし）。その 1 段あと、[stage の run](https://github.com/Keyhole-Koro/Synthify/actions/runs/30684533240) で今度はここで落ちています:

```
#19 [builder 6/6] RUN bun run build
0.434 $ next build
0.437 /bin/sh: next: not found
0.437 error: script "build" exited with code 127
```

builder ステージは `COPY --from=deps /repo/node_modules ./node_modules` の 1 行だけを持ち込んでいて、「bun は全依存をワークスペースルートに hoist する」ことを前提にしています。**そうなっていません。** ワークスペースメンバー自身の依存はそのメンバー配下にインストールされるため、`next` と bin の symlink は `apps/monitor/ui/node_modules/.bin` にあり、root の `node_modules/.bin` には**そもそも入りません**。`bun run build` は `/repo/apps/monitor/ui` で走るので、PATH に next が無い状態になります。

## 変更内容

そのディレクトリも builder に持ち込む COPY を 1 行追加しただけです。既存行と同じく `COPY . .` の手前に置いています（`.dockerignore` が `**/node_modules` を除外しているので、ソースのコピーで上書きされることはありません）。

`apps/web` の node_modules は**あえて入れていません**。monitor は apps/web から何も import せず、lockfile 上の関係があるだけです。

## 検証

Docker はこの環境で使えないので実ビルドは通していませんが、**bun の挙動そのものは手元で実測して確認しました**（bun 1.3.11）。

最小のワークスペースを作って `semver`（bin を持つ小さなパッケージ）をワークスペースメンバーの依存として install:

```
=== root の .bin ===      → (無し)
=== packages/a/node_modules/ ===  → semver
=== packages/a/node_modules/.bin/ === → semver
```

root の `.bin` は**空**で、bin はワークスペース側にだけ置かれました。

さらに、root の node_modules は残したままワークスペース側の node_modules だけ退避して `bun run build` を実行すると:

```
$ semver --help
/usr/bin/bash: line 1: semver: command not found
error: script "build" exited with code 127
```

**CI と同一の "command not found" + exit 127** が再現します。原因は確定と考えています。

## デプロイの現状

- `main` / `stage` は `b5e8923`、`prod` はまだ `46a82c3`
- DB マイグレーション 0021〜0024 は stage / prod とも適用済み
- api / worker / eval のイメージは両環境とも push 済み。**monitor だけが未完了**で、そのため `Terraform apply (full)` 以降が skip され、Cloud Run は旧コードのままです

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_