### PR TITLE
ci: build every container image on pull requests

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,96 @@
+name: Images
+
+# Build every container image on PRs.
+#
+# Until this existed, nothing built these Dockerfiles except deploy-backend.yml,
+# so the first thing to ever parse a Dockerfile change was a deploy against a
+# real environment — one verification per production deploy attempt. The monitor
+# image broke twice that way in a row (a file: dependency missing from the deps
+# stage, then the workspace node_modules missing from the builder stage), and
+# both were plain build errors a PR check would have caught.
+#
+# Nothing here pushes or needs cloud credentials: the images are built and
+# thrown away. Correctness of the build is the whole signal.
+
+on:
+  pull_request:
+    paths:
+      - apps/**
+      - internal/**
+      - go.mod
+      - go.sum
+      - bun.lock
+      - package.json
+      - .dockerignore
+      - .github/workflows/images.yml
+  push:
+    branches:
+      - main
+    paths:
+      - apps/**
+      - internal/**
+      - go.mod
+      - go.sum
+      - bun.lock
+      - package.json
+      - .dockerignore
+      - .github/workflows/images.yml
+
+concurrency:
+  group: images-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      # One image failing should not hide the state of the other three.
+      fail-fast: false
+      matrix:
+        include:
+          - image: api
+            dockerfile: apps/api/Dockerfile
+            build_args: ""
+          - image: worker
+            dockerfile: apps/worker/Dockerfile
+            build_args: ""
+          - image: eval
+            dockerfile: apps/eval/Dockerfile
+            build_args: ""
+          # NEXT_PUBLIC_* are baked into the client bundle at build time, so the
+          # build needs them present. These are placeholders: the image is
+          # discarded, and only whether it builds is being checked.
+          - image: monitor
+            dockerfile: apps/monitor/ui/Dockerfile
+            build_args: >-
+              --build-arg NEXT_PUBLIC_FIREBASE_API_KEY=ci-placeholder
+              --build-arg NEXT_PUBLIC_FIREBASE_PROJECT_ID=ci-placeholder
+              --build-arg NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=ci-placeholder.firebaseapp.com
+              --build-arg NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=ci-placeholder.appspot.com
+              --build-arg NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=0
+              --build-arg NEXT_PUBLIC_FIREBASE_APP_ID=ci-placeholder
+
+    steps:
+      # The monitor image copies apps/web/vender/paper-in-paper, a submodule, so
+      # it has to be in the build context.
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.image }} image
+        run: |
+          set -euo pipefail
+          # No --push and no --load on purpose: the result is discarded, so the
+          # build runs without registry credentials and without spending time
+          # unpacking the image into the runner's docker daemon.
+          #
+          # Cache scope is distinct from deploy-backend.yml's <image>-<env>
+          # scopes so PR builds and real deploys never evict each other.
+          docker buildx build \
+            --cache-from "type=gha,scope=ci-${{ matrix.image }}" \
+            --cache-to   "type=gha,scope=ci-${{ matrix.image }},mode=max" \
+            ${{ matrix.build_args }} \
+            -f "${{ matrix.dockerfile }}" .


### PR DESCRIPTION
## なぜ

4つの Dockerfile を CI が**一度もビルドしていませんでした**（grep で確認済み。`deploy-backend.yml` 以外に `docker build` は存在しない）。つまり Dockerfile の変更を最初に解釈するのは**実環境へのデプロイ**で、検証 1 回のコストが本番デプロイ 1 回分でした。

monitor イメージが 2 回連続で壊れたのはこれが原因です:

1. deps ステージに `file:` 依存（submodule）の実体が無く `bun install` が失敗（#31）
2. builder ステージにワークスペースの node_modules が無く `next: not found` / exit 127（#32）

どちらも「PR チェックなら数分で分かるただのビルドエラー」でした。

## 変更内容

`.github/workflows/images.yml` を新規追加。4イメージを matrix で並列ビルドします。

**push も load もしません。** イメージは捨てるので、**クラウド認証情報が一切不要**で、どの PR でも走ります。シグナルは「ビルドが通るか」だけです。

- `fail-fast: false` — 1つ壊れても他3つの状態が隠れない
- `submodules: recursive` — monitor は `apps/web/vender/paper-in-paper`（submodule）を COPY するのでビルドコンテキストに必要
- monitor には `NEXT_PUBLIC_*` のプレースホルダを build-arg で渡す。クライアントバンドルに焼き込まれるのでビルド時に必要だが、イメージは捨てるので値は何でもよい
- キャッシュスコープは `ci-<image>`。デプロイ側の `<image>-<env>` と分離してあるので、PR ビルドと実デプロイが互いのキャッシュを追い出しません

## このPRのCIについて（重要）

`main` はまだ `b5e8923` で **#32 が入っていません**。したがって **このPRでは `monitor` のジョブが意図的に赤くなります** — `next build` が exit 127 で落ちる、まさに #32 が直すバグです。`api` / `worker` / `eval` は緑になるはずです。

これは不具合ではなく、**新しいチェックが実際に機能している証拠**として扱ってください。#32 がマージされれば緑になります。順番としては #32 を先にマージするのが素直です。

## 検証

Docker がこの環境に無いので実ビルドは走らせていませんが、ワークフローの正しさは以下まで確認しました:

- YAML パース OK、matrix 4 件が意図どおり展開されること
- 4つの Dockerfile パスがすべて実在すること
- monitor の `--build-arg` 名 6 個が Dockerfile の `ARG` 宣言と**過不足なく一致**すること（双方向で差分チェック）
- matrix を実際に展開した `run` を `bash -n` で構文チェック。`build_args` が空（Go 3種）のケースと 6 個渡すケースの両方が有効なシェルになること

## コスト

デプロイのログ実測で Go イメージは 1 つあたり約 150 秒。matrix 並列なので実時間は最長イメージぶんで、GHA キャッシュが温まれば以降は短くなります。

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_