### PR TITLE
test(e2e): stop the sharing spec depending on leftover share links

### DIFF
--- a/apps/web/e2e/sharing.spec.ts
+++ b/apps/web/e2e/sharing.spec.ts
@@ -11,6 +11,18 @@ test('creates a public read-only link and revokes access', async ({ browser, pag
   await page.getByText('ワークスペース', { exact: true }).first().click();
   await page.getByText('Synthify Dev Seed', { exact: true }).first().click();
   await page.getByRole('button', { name: '共有', exact: true }).last().click();
+
+  // This test shares a workspace every other test also uses, and a link it
+  // creates outlives a failed run. Start from a known state instead of
+  // inheriting whatever earlier runs left behind: revoke every existing link
+  // before creating the one under test. (.first() is deliberate here — the
+  // point is to remove all of them, not to pick one.)
+  const revokeButtons = page.getByTitle('リンクを失効');
+  for (let remaining = await revokeButtons.count(); remaining > 0; remaining--) {
+    await revokeButtons.first().click();
+    await expect(revokeButtons).toHaveCount(remaining - 1);
+  }
+
   await page.getByRole('button', { name: 'リンク作成' }).click();
 
   const linkCode = page.locator('code').last();
@@ -27,7 +39,14 @@ test('creates a public read-only link and revokes access', async ({ browser, pag
   await expect(viewer.getByRole('button', { name: '削除', exact: true })).toHaveCount(0);
   await expect(viewer.getByRole('button', { name: '共有', exact: true })).toHaveCount(0);
 
-  await page.getByTitle('リンクを失効').click();
+  // The list was emptied above and this test created exactly one link, so the
+  // only revocable link is the one the viewer is holding. State that as an
+  // assertion rather than leaving it implied: previously this was a bare
+  // getByTitle().click(), which revoked "whichever link is first" and, once a
+  // leftover existed, silently revoked an unrelated one — making the assertion
+  // below fail for a reason that has nothing to do with sharing.
+  await expect(revokeButtons).toHaveCount(1);
+  await revokeButtons.click();
   await viewer.reload();
   await expect(viewer.getByRole('heading', { name: 'リンクを開けません' })).toBeVisible();
   await anonymous.close();


### PR DESCRIPTION
## なぜ

[#33 の e2e (1)](https://github.com/Keyhole-Koro/Synthify/actions/runs/30685787444/job/91331217251) が落ちました。#33 はワークフローファイルを1本追加しただけで、`main` の同一コミット（`f92c4e5`）は4分前に success しています。

3回の試行が**それぞれ別の場所**で落ちているのが決定的でした:

| 試行 | 場所 | エラー |
|---|---|---|
| 初回 | `sharing.spec.ts:17` | `waiting for locator('code').last()` タイムアウト |
| retry 1 | `sharing.spec.ts:30` | `strict mode violation ... resolved to **2** elements` |
| retry 2 | `sharing.spec.ts:30` | `strict mode violation ... resolved to **3** elements` |

**2個 → 3個と1つずつ増えています。**

初回は「リンク作成後に URL が UI に出るのを待ち切れなかった」だけですが、**リンク自体はサーバ側に作られて残ります**。このテストは `Dev seed workspace` という共有のワークスペースを使い回し、失敗時に後始末をしないので、試行のたびに残骸が1本積み上がる。結果、`getByTitle('リンクを失効')` のマッチ数が毎回1つ増えて落ちる。

**1回のタイミング揺れが、その run の残り全部を確実に失敗させる構造**でした。リトライが救済にならず、悪化させています。

## 変更内容

自分が所有していない状態に依存しないようにする、という一点です。

**1. テスト開始時に既存リンクを全部失効させる** — 過去の run が何を残していようと、既知の状態から始まる。ループ内の `.first()` は意図的です（1つ選ぶのではなく、全部消すのが目的）。

**2. 失効の直前に「リンクは1本」であることをアサートする** — 呼び出し側で `.first()` にするのが手っ取り早い修正ですが、**それは誤りです**。`SharePanel.tsx` の一覧は1行=1リンクで、行ごとに自分のトークンと失効ボタンを持ちます。残骸があると「first」は viewer が握っているリンクとは限らず、直後の「`リンクを開けません` が見えること」が**共有機能と無関係な理由で落ちる**（あるいは壊れているのに緑になる）。件数をアサートしておけば、前提が崩れたときに黙って別のボタンを押すのではなく、はっきり失敗します。

## 扱っていないこと

**初回タイムアウトの原因そのものは直していません。** 診断ログに `[HMR]` と初回アクセスの `GET /view?token=... 200 in 2.1s (next.js: 1979ms)` が出ており、**e2e が Next の dev サーバに対して走っています**。コールドコンパイル待ちは構造的なフレーク源で、本筋の対策は**プロダクションビルドに対して e2e を回す**ことです。変更の性質が違うので、意図的にこの PR には含めていません。

## 検証

この環境では compose スタックを立てられないため、**e2e 自体は実行していません**。確認できたのは以下です:

- `tsc --noEmit --skipLibCheck --noResolve` で構文・型エラーが無いこと（残るのは `--noResolve` 由来の module 未解決と implicit any のみで、いずれも想定内）
- `SharePanel.tsx` の DOM 構造を読み、一覧が `<li>` 1行=1リンクで、同じ行に `<code>{shareLinkUrl(l.token)}</code>` と `onRevoke(l.token)` の失効ボタンが入っていることを確認。`.first()` が誤りである根拠はここです
- ロケータを `<li>` の入れ子構造に依存させない形（件数アサート）にしてあるので、`SharePanel` がどこにマウントされていても壊れません

実地の確認は CI の e2e 頼みになります。

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_