### PR TITLE
test(e2e): run the suite against the web production build

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -63,12 +63,19 @@ jobs:
         working-directory: apps/web
         run: bun run build
 
-  # Compile the API and worker once, up front, instead of letting every e2e
-  # shard's Docker Compose boot rebuild them from a cold cache. In-container the
-  # golang image's build cache lives in a named volume that starts empty on each
-  # runner, so every shard paid a ~4-minute `go build` floor. Building static
-  # (CGO_ENABLED=0) binaries here — cached natively by setup-go — and injecting
-  # them into the compose stack removes that floor from both shards.
+  # Build everything the e2e stack runs, once, instead of letting every shard's
+  # Docker Compose rebuild it from a cold cache.
+  #
+  # For Go: in-container the golang image's build cache lives in a named volume
+  # that starts empty on each runner, so every shard paid a ~4-minute `go build`
+  # floor. Static (CGO_ENABLED=0) binaries built here — cached natively by
+  # setup-go — remove that floor from both shards.
+  #
+  # For web: the shards used to run `next dev`, which compiles each route on
+  # first request. That is both slower and not what ships (apps/web is an
+  # `output: 'export'` static site on Firebase Hosting), and the compile latency
+  # showed up as flaky navigation timeouts. Export it once here and let the
+  # shards serve the result.
   binaries:
     runs-on: ubuntu-latest
     steps:
@@ -81,6 +88,18 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Build API and worker binaries
         env:
           CGO_ENABLED: "0"
@@ -91,11 +110,37 @@ jobs:
           go build -buildvcs=false -o .e2e-bin/synthify-api ./apps/api/cmd/server
           go build -buildvcs=false -o .e2e-bin/synthify-worker ./apps/worker/cmd/server
 
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # NEXT_PUBLIC_* are baked into the bundle at build time, so this build has
+      # to reproduce the environment the shards' compose stack would have given
+      # `next dev`. The workflow-level env above covers most of it, but compose
+      # also defaults these three (compose.yaml, frontend.environment) and they
+      # are not optional: without them the bundle points the Firebase SDK at
+      # real Firebase instead of the emulator and every signed-in spec fails.
+      # Keep them in step with compose.yaml's defaults.
+      - name: Build web static export
+        working-directory: apps/web
+        env:
+          NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_URL: http://127.0.0.1:9099
+          NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR_HOST: 127.0.0.1
+          NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR_PORT: "8282"
+        run: bun run build
+
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:
           name: e2e-binaries
           path: .e2e-bin
+          include-hidden-files: true
+          retention-days: 1
+
+      - name: Upload web export
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-web-export
+          path: apps/web/out
           include-hidden-files: true
           retention-days: 1
 
@@ -156,6 +201,14 @@ jobs:
       - name: Make binaries executable
         run: chmod +x .e2e-bin/*
 
+      # The prebuilt static export (see the binaries job). E2E_WEB_EXPORT below
+      # makes the compose frontend serve this instead of running `next dev`.
+      - name: Download web export
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-web-export
+          path: apps/web/out
+
       # The compose frontend container runs as ${LOCAL_UID:-1000}, but the
       # runner's workspace is owned by uid 1001 — align them or the bind
       # mount is read-only to the container.
@@ -168,6 +221,10 @@ jobs:
         working-directory: apps/web
         env:
           E2E_WORKER_FIXTURE: "true"
+          # Serve the production build, not `next dev`. Playwright starts the
+          # compose stack from this step (see webServer in playwright.config.ts),
+          # so compose reads it from here.
+          E2E_WEB_EXPORT: "true"
         run: |
           shard="--shard=${{ matrix.shard }}/${{ strategy.job-total }}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,12 @@
 name: synthify-dev
 
 services:
+  # Runs `next dev` by default, which is what you want while developing.
+  # E2E_WEB_EXPORT=true instead serves a prebuilt static export through
+  # scripts/serve-web-export.mjs — the same shape production has (apps/web sets
+  # output: 'export' and ships to Firebase Hosting). CI uses that mode so the
+  # suite exercises what actually ships and stops paying dev's on-demand
+  # compilation, which is a standing source of timing flake.
   frontend:
     image: oven/bun:1
     user: "${LOCAL_UID:-1000}:${LOCAL_GID:-1000}"
@@ -11,6 +17,14 @@ services:
         if [ ! -f /workspace/apps/web/package.json ]; then
           echo "apps/web/package.json not found. Waiting for web implementation...";
           sleep infinity;
+        fi;
+        if [ "${E2E_WEB_EXPORT:-}" = "true" ]; then
+          if [ ! -f /workspace/apps/web/out/index.html ]; then
+            echo "E2E_WEB_EXPORT=true but apps/web/out is missing. Refusing to fall back to the dev server." >&2;
+            exit 1;
+          fi;
+          echo "serving prebuilt static export";
+          exec bun /workspace/scripts/serve-web-export.mjs /workspace/apps/web/out;
         fi;
         if [ ! -x /workspace/apps/web/node_modules/.bin/next ]; then
           cd /workspace;

--- a/scripts/serve-web-export.mjs
+++ b/scripts/serve-web-export.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env bun
+//
+// Serve apps/web's Next static export the way Firebase Hosting serves it in
+// production.
+//
+// apps/web sets `output: 'export'` (see next.config.ts), so production is a
+// pile of static files behind a catch-all rewrite to /index.html
+// (firebase.json). `next start` cannot serve that — Next refuses to run it
+// against an exported build — so this stands in for Hosting when the e2e stack
+// runs against a production build instead of `next dev`.
+//
+// Deliberately dependency-free: a `bunx serve` here would resolve a version at
+// container start, which is exactly how the Playwright browser mismatch got in.
+//
+// Usage: bun scripts/serve-web-export.mjs [root]   (default apps/web/out)
+
+import { statSync } from 'node:fs';
+import { join, resolve, sep } from 'node:path';
+
+const root = resolve(process.argv[2] ?? 'apps/web/out');
+const port = Number(process.env.PORT ?? 5173);
+
+function isFile(path) {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+if (!isFile(join(root, 'index.html'))) {
+  console.error(`[serve-web-export] no static export at ${root} (index.html missing).`);
+  console.error('[serve-web-export] build it first: cd apps/web && bun run build');
+  process.exit(1);
+}
+
+const indexHTML = join(root, 'index.html');
+
+// Hosting resolves a request against the exported tree, then rewrites anything
+// left over to /index.html so client-side routing takes it. The export writes
+// routes as directories (out/view/index.html), hence the second candidate.
+function resolveFile(pathname) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    return indexHTML;
+  }
+
+  const target = resolve(root, `.${decoded}`);
+  // resolve() collapses any ../ before this check, so a traversal attempt lands
+  // outside root and falls through to the SPA entrypoint rather than escaping.
+  if (target !== root && !target.startsWith(root + sep)) return indexHTML;
+
+  for (const candidate of [target, join(target, 'index.html'), `${target}.html`]) {
+    if (isFile(candidate)) return candidate;
+  }
+  return indexHTML;
+}
+
+Bun.serve({
+  port,
+  hostname: '0.0.0.0',
+  fetch(request) {
+    const { pathname } = new URL(request.url);
+    // 200 on the fallback, not 404: that is what the Hosting rewrite does, and
+    // the app renders its own not-found states client-side.
+    return new Response(Bun.file(resolveFile(pathname)));
+  },
+});
+
+console.log(`[serve-web-export] serving ${root} on http://0.0.0.0:${port}`);


### PR DESCRIPTION
#34 で話した (c) です。

## なぜ

e2e スタックは frontend を `next dev` で起動し、しかも起動のたびに `rm -rf .next` しています。全ルートが初回リクエストでオンデマンドコンパイルされる状態です。

コストは #34 の run に実測で出ていました。**同じ run の同じルート**で:

| | 応答 | Next の処理 |
|---|---|---|
| 初回 | 2.1s | `next.js: 1979ms` |
| 後のリトライ | 133ms | `next.js: 6ms` |

`playwright.config.ts` は既にこれを回避策で凌いでいます —「unbounded browser workers can **starve page compilation**」というコメント付きで CI を `workers: 1` に固定。

**そして、これは出荷するものではありません。** `apps/web` は `output: 'export'`（`next.config.ts`）の静的サイトで、Firebase Hosting に `** → /index.html` の catch-all rewrite（`firebase.json`）で載ります。つまり e2e は**ユーザーに一度も届かないビルド構成を検証してきました**。

## 変更内容

**ビルドは `binaries` ジョブで1回だけ**行い、各シャードは成果物を配って serve するだけにしました。同ジョブが Go バイナリで既にやっている形をそのまま踏襲しています。

compose の中でビルドさせる案は採りませんでした。オンデマンドコンパイルを「数分の起動待ち」に置き換えるだけで、`playwright.config.ts` の readiness ゲートは API health しか見ていないため、frontend がまだ立っていないうちにテストが走り出します。**事前ビルドなら frontend は即座に立つので、この問題自体が発生しません。**

`scripts/serve-web-export.mjs` が Hosting の代役です。解決順は 完全一致ファイル → `<path>/index.html` → `<path>.html` → `/index.html` を **200 で**返す（rewrite の挙動。ディープリンクが動くのはこれのおかげ）。

- **`next start` は使えません** — Next は export 済みビルドに対して起動を拒否します。`apps/web` の `start` スクリプトは実質死んでいます（別件）
- **依存ゼロにしてあります。** `bunx serve` はコンテナ起動時にバージョンを解決することになり、**それはまさに Playwright のブラウザ不整合が入り込んだ経路**なので避けました

## 一番の落とし穴（見つけて潰しました）

`NEXT_PUBLIC_*` は**ビルド時に bundle へ焼き込まれます**。ワークフロー冒頭の env はほとんどを網羅していますが、**compose だけが既定値を与えている変数が3つあります**:

- `NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_URL`
- `NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR_HOST`
- `NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR_PORT`

これらが無いままビルドすると、**bundle が Firebase SDK をエミュレータではなく実 Firebase に向けます**。ログイン系のスペックが全滅します。ビルドステップに明示し、compose の既定値と揃える旨をコメントに残しました。

## ローカルは変わりません

`docker compose up` は従来どおり dev サーバ + ホットリロード。export 経路は `E2E_WEB_EXPORT` によるオプトインです。**そのうえで、フラグが立っているのに export が無ければコンテナは失敗します** — dev に黙って落ちて「壊れた成果物のまま緑」になるのを防ぐためです。

## 検証

compose スタックは立てられないので **e2e 自体は動かしていません**。実際に動かして確認したのは以下です:

**静的サーバのルーティング** — フィクスチャを作って実リクエストを投げました:

| リクエスト | 結果 |
|---|---|
| `/` | 200 `index.html` |
| `/_next/static/app.js` | 200 実ファイル |
| `/view` | 200 `view/index.html`（今回問題になったルート） |
| `/view?token=abc` | 200 同上（クエリ保持） |
| `/about` | 200 `about.html` |
| `/does/not/exist` | **200 `index.html`**（rewrite 相当） |
| `/../../../etc/passwd` | 200 `index.html`（traversal は封じ込め） |

**export 欠落時** — 終了コード 1 とビルド手順の案内を出すことを確認。

**compose の command** — YAML パース後の文字列を取り出し、`E2E_WEB_EXPORT` が空／`true` の両方で `bash -n` 構文チェック。さらに実際に走らせて、(1) export 無し＋フラグ有り → 明示的に exit 1、(2) export 有り → `exec` で静的サーバが 0.0.0.0:5173 に着地、を確認しました。

**その他** — `web.yml` / `compose.yaml` の YAML パース、`apps/web/.gitignore:4` が `out` を既に無視していること（成果物の展開で作業ツリーが汚れない）。

## 意図的にやっていないこと

- **`e2e-nightly.yml` は dev のまま**です。別ワークフローなので分けました
- **`checks` ジョブも `bun run build` を実行しており、ビルドが2回**走ります。`checks` は e2e と並列で走らせる設計なので、依存させると直列化して遅くなる。重複は許容し、整理は別途と判断しました
- **新しい失敗が出る可能性があります。**「dev では動いていたが production build では動かない」ものが炙り出されるのは、この変更の目的そのものです

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_