### PR TITLE
ci(web): derive the browser env from compose instead of restating it

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -6,18 +6,15 @@ on:
     branches:
       - main
 
-# Shared browser-app env. The API refuses to boot without a Stripe key and at
-# least one price ID; E2E specs mock BillingService in the browser, so dummies
-# suffice.
+# The API refuses to boot without a Stripe key and at least one price ID; E2E
+# specs mock BillingService in the browser, so dummies suffice.
+#
+# NEXT_PUBLIC_* are deliberately NOT here. They belong to the stack the tests
+# run against, which is compose.yaml, and restating a subset of them here is how
+# they drifted: three emulator variables only ever existed in compose. Jobs that
+# need them derive them with scripts/compose-browser-env.sh.
 env:
   SKIP_ENV_VALIDATION: true
-  NEXT_PUBLIC_API_BASE_URL: http://localhost:8080
-  NEXT_PUBLIC_FIREBASE_API_KEY: demo-api-key
-  NEXT_PUBLIC_FIREBASE_PROJECT_ID: demo-synthify
-  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: demo-synthify.firebaseapp.com
-  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: demo-synthify.appspot.com
-  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: "1234567890"
-  NEXT_PUBLIC_FIREBASE_APP_ID: 1:1234567890:web:demo-synthify
   STRIPE_SECRET_KEY: sk_test_e2e_dummy
   STRIPE_PRO_PRICE_ID_JPY: price_e2e_dummy_jpy
 
@@ -50,6 +47,11 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      # NEXT_PUBLIC_* come from compose.yaml, the definition of the stack these
+      # tests run against, rather than being restated here. See the script.
+      - name: Resolve browser env from compose
+        run: bash scripts/compose-browser-env.sh frontend >> "$GITHUB_ENV"
 
       - name: Lint
         working-directory: apps/web
@@ -133,6 +135,11 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      # NEXT_PUBLIC_* come from compose.yaml, the definition of the stack these
+      # tests run against, rather than being restated here. See the script.
+      - name: Resolve browser env from compose
+        run: bash scripts/compose-browser-env.sh frontend >> "$GITHUB_ENV"
 
       # Installed from apps/web, not the repo root: the root package.json is a
       # bun workspace root with no Playwright dependency, so `bunx playwright`
@@ -220,6 +227,11 @@ jobs:
       - name: Install Chromium
         working-directory: apps/monitor/ui
         run: bun run playwright:install
+
+      # NEXT_PUBLIC_* come from compose.yaml, the definition of the stack these
+      # tests run against, rather than being restated here. See the script.
+      - name: Resolve browser env from compose
+        run: bash scripts/compose-browser-env.sh monitor >> "$GITHUB_ENV"
 
       - name: Capture monitor screenshots
         working-directory: apps/monitor/ui

--- a/scripts/compose-browser-env.sh
+++ b/scripts/compose-browser-env.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Print the NEXT_PUBLIC_* environment a compose service hands its container, as
+# KEY=VALUE lines suitable for appending to $GITHUB_ENV.
+#
+# compose.yaml is where the local dev and e2e browser environment is defined,
+# and those values are not plain constants — several interpolate port variables
+# (NEXT_PUBLIC_API_BASE_URL takes BACKEND_PORT, the emulator URLs take
+# FIREBASE_AUTH_PORT / FIREBASE_FIRESTORE_PORT). CI used to restate a subset of
+# them by hand in web.yml, and the subset drifted: the three emulator variables
+# existed only in compose. That was invisible while CI only ever ran the app
+# through compose, and became a silent break the moment CI built the bundle
+# itself, because NEXT_PUBLIC_* are baked in at build time — a bundle built
+# without them points the Firebase SDK at real Firebase instead of the emulator.
+#
+# `docker compose config` resolves the interpolation and needs no daemon.
+#
+# Usage: scripts/compose-browser-env.sh frontend >> "$GITHUB_ENV"
+
+set -euo pipefail
+
+service="${1:?usage: compose-browser-env.sh <compose-service>}"
+compose_file="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/compose.yaml"
+
+resolved="$(docker compose -f "$compose_file" config --format json \
+  | jq -er --arg svc "$service" '
+      .services[$svc].environment
+      | to_entries[]
+      | select(.key | startswith("NEXT_PUBLIC_"))
+      | "\(.key)=\(.value)"
+    ')"
+
+# An empty result means the service was renamed or its browser env moved. Fail
+# rather than let a build quietly proceed with none of these set.
+if [ -z "$resolved" ]; then
+  echo "no NEXT_PUBLIC_* variables found for compose service '${service}'" >&2
+  exit 1
+fi
+
+printf '%s\n' "$resolved"


### PR DESCRIPTION
## なぜ

dev / e2e のブラウザ環境が**2箇所で宣言**されていました。`compose.yaml` の frontend サービスと、`web.yml` のワークフロー env。両者は一致していなければならないのに、それを担保する仕組みが無く、実際にずれていました。

| | 宣言数 |
|---|---|
| `compose.yaml` frontend | 10 |
| `web.yml` workflow env | 7 |

**足りない3つはエミュレータ関連**でした:

```
NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_URL
NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR_HOST
NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR_PORT
```

CI がアプリを compose 経由でしか動かさないうちは、compose が実行時に渡すので**見えない不整合**でした。しかし CI 自身がバンドルをビルドした瞬間に牙を剥きます。`NEXT_PUBLIC_*` は**ビルド時に焼き込まれる**ので、これらが無いバンドルは Firebase SDK を**エミュレータではなく実 Firebase に向け**、ログイン系のスペックが全滅します。しかも原因からは程遠い見た目の失敗になります。

私自身、#35 でこれを踏みました。そのときの対処は「3つを手でコピーして『compose と揃えること』とコメントを添える」でしたが、それは担保としては弱く、`__synthifyE2E` のコメントと同じ種類の約束にすぎません。

## 変更内容

restate をやめて**導出**します。`compose.yaml` は既にテスト対象スタックの定義そのもので、`docker compose config` が補間を解決してくれます。

**そもそも静的なコピーでは正しくあり得ませんでした** — これらの値の複数はポート変数を合成しています（`NEXT_PUBLIC_API_BASE_URL` は `BACKEND_PORT`、エミュレータ URL は `FIREBASE_*_PORT`）。

`docker compose config` は**デーモン不要**なので、ただの run ステップとして成立します。

`scripts/compose-browser-env.sh <service>` が `KEY=VALUE` を出力し、各ジョブが 1 行で `$GITHUB_ENV` に流し込みます。適用先は 3 ジョブ:

- `checks` / `e2e` → `frontend`
- `monitor-screenshots` → `monitor`

`STRIPE_*` と `SKIP_ENV_VALIDATION` はワークフロー env に残しました。あれはスタックではなくワークフローに属する値です。

スクリプトは、サービスの `NEXT_PUBLIC_*` が 1 件も取れなければ**失敗します**。サービス名の変更や env の移動が、「何も設定されないまま静かに進むビルド」ではなく落ちたステップとして表に出ます。

## 検証

この環境に docker デーモンは無い（＝ビルドも実行もできない）のですが、**`docker compose config` はデーモン不要なので、この変更の中核はここで実際に動かして確認できました。**

**導出値と既存宣言の突き合わせ**（`origin/main` の web.yml と比較）:

| 変数 | 判定 |
|---|---|
| `NEXT_PUBLIC_API_BASE_URL` | 一致 |
| `NEXT_PUBLIC_FIREBASE_API_KEY` | 一致 |
| `NEXT_PUBLIC_FIREBASE_APP_ID` | 一致 |
| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | 一致 |
| `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | 一致 |
| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | 一致 |
| `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | 一致 |
| `NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_URL` | ★ 新規に供給 |
| `NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR_HOST` | ★ 新規に供給 |
| `NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR_PORT` | ★ 新規に供給 |

**既存7件は完全一致**なので、その範囲では挙動を変えません。ポート合成も期待どおり解決されています（`http://localhost:8080`、`http://127.0.0.1:9099`）。

その他:
- `frontend` / `monitor` 両サービスで正しい集合が出ること
- 存在しないサービス名 → 非ゼロ終了、引数なし → 使用法を出して終了
- `$GITHUB_ENV` 形式で 10 行書き込まれること
- `web.yml` の YAML パース、ハードコードされた `NEXT_PUBLIC_` が 1 つも残っていないこと

## 補足

- `.env.example` にも同じ値が載っています。あちらは開発者向けのテンプレートで CI からは読まれないため、今回は触っていません
- `e2e-nightly.yml` は `NEXT_PUBLIC_*` を宣言しておらず compose 依存なので、影響を受けません
- これがマージされれば、#35 で手動コピーした3行は不要になります（#35 側を rebase して削除します）

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_