### PR TITLE
fix(monitor): refuse the local database default in production

### DIFF
--- a/apps/monitor/ui/src/config.ts
+++ b/apps/monitor/ui/src/config.ts
@@ -1,12 +1,22 @@
 import { z } from 'zod';
 
+// compose と `bun run dev` に対しては正しく、それ以外のどこに届いても間違っている値。
+// 既定値を持てるのは「その既定値が正しい環境にしか届かない」ときだけ、という取り決めに
+// 従い、これが本番に届いていないことは消費側 (src/lib/db.ts) が検査する。
+//
+// ここで弾かないのは意図的。このモジュールは `next build` からも import されるが、
+// ビルド時に実行時シークレットは存在しない設計になっている
+// (apps/monitor/ui/Dockerfile 参照)。ここで必須にするとビルドが落ちる。
+//
+// docs/architecture/environment-variables.md
+export const LOCAL_MONITOR_DATABASE_URL =
+  'postgres://monitor@127.0.0.1:5432/synthify?sslmode=disable';
+
 const envSchema = z.object({
   // BFF (Next.js Route Handlers) は MONITOR_DATABASE_URL で Postgres を直接参照する。
   // monitor ロールに GRANT SELECT が与えられた read-only DSN を指す想定
   // (db/migrations/0014_monitor_role.up.sql, view は 0013_monitor_views.up.sql)。
-  MONITOR_DATABASE_URL: z
-    .string()
-    .default('postgres://monitor@127.0.0.1:5432/synthify?sslmode=disable'),
+  MONITOR_DATABASE_URL: z.string().default(LOCAL_MONITOR_DATABASE_URL),
 
   // Firebase ID トークン検証に使う project ID (apps/api と共通)。
   // FIREBASE_AUTH_EMULATOR_HOST が設定されていればエミュレータに接続する。

--- a/apps/monitor/ui/src/lib/db.ts
+++ b/apps/monitor/ui/src/lib/db.ts
@@ -1,5 +1,5 @@
 import { Pool } from 'pg';
-import { config } from '../config';
+import { config, LOCAL_MONITOR_DATABASE_URL } from '../config';
 
 // Next.js の dev mode で HMR が走るたびに新しい Pool ができないよう、
 // globalThis にキャッシュする。
@@ -9,8 +9,27 @@ declare global {
 }
 
 function createPool(): Pool {
+  // MONITOR_DATABASE_URL が未設定のとき、config は local 向けの既定値を返す。それは
+  // compose では正しく、デプロイ先では「起動には成功してダッシュボードが何も出さない」
+  // という一番気づきにくい壊れ方になる。既定値のまま本番に届いていたら、静かに繋ぎに
+  // いくのではなく落とす。
+  //
+  // 検査をここに置いているのは、Pool を作るのは実際にクエリが要るときだけで、
+  // `next build` からは到達しないため。config 側で必須にするとビルドが落ちる。
+  const connectionString = config.MONITOR_DATABASE_URL;
+  if (
+    process.env.NODE_ENV === 'production' &&
+    connectionString === LOCAL_MONITOR_DATABASE_URL
+  ) {
+    throw new Error(
+      'MONITOR_DATABASE_URL is not set. Refusing to fall back to the local default ' +
+        'in production: the dashboard would start and silently read nothing. ' +
+        'See docs/architecture/environment-variables.md.',
+    );
+  }
+
   return new Pool({
-    connectionString: config.MONITOR_DATABASE_URL,
+    connectionString,
     max: 5,
     idleTimeoutMillis: 30_000,
   });


### PR DESCRIPTION
> **stacked PR**: base は #37。差分は monitor の 2 ファイルのみ。#37 → この PR の順です。

環境設定の責務を決める作業の **C**（原則5「必須が欠けたら落ちる」と既定値の制約の適用）。

## なぜ

`MONITOR_DATABASE_URL` の既定値は `postgres://monitor@127.0.0.1:5432/synthify` で、**compose では正しく、それ以外のどこでも間違っています**。この値が Cloud Run に届くのを止めるものが何もありませんでした。

そこで起きる壊れ方が厄介です。**ダッシュボードは起動に成功し**、全クエリが存在しない DB に飛び、結果は「壊れた画面」ではなく「空のダッシュボード」になります。

これは仮定の話ではありません。`synthify-monitor-database-dsn` は stage / prod のどちらにも version がありませんでした。デプロイが止まったのは `deploy-backend.yml` の secret ゲート、つまり**ワークフローのステップであってアプリではありません**。ゲートが無ければ monitor はこの既定値で起動していました。

## 変更内容

既定値を持ってよいのは、その既定値が正しい環境にしか届かないとき（#37 の原則）。これは届いてしまうので、**消費側が拒否します** — production で DSN が local 既定値のままなら、それは「設定されなかった」ことなので `createPool()` は繋がずに落ちます。

**検査を `db.ts` に置いたのは意図的です。** `config.ts` は `next build` からも import されますが、ビルド時に実行時シークレットは存在しない設計です（Dockerfile は `NEXT_PUBLIC_*` を build-arg で渡し、`MONITOR_DATABASE_URL` は意図的に Cloud Run に委ねている）。パース時に必須化すると**イメージのビルドが落ちます**。`getPool()` は遅延シングルトンなので、Pool が作られるのは実際にクエリが必要になったとき＝値が本物でなければならないときだけです。

## 検証

monitor アプリはこの環境で起動できないため、ガードのロジックを抽出して実際に走らせました:

| NODE_ENV | DSN | 結果 | 期待 |
|---|---|---|---|
| production | 未設定 | **拒否** | 落ちるべき ✓ |
| production | 実 DSN | 接続 | 繋ぐべき ✓ |
| development | 未設定 | 既定値で接続 | ✓ |
| development | 指定値 | 指定値で接続 | ✓ |

**local の体験は変わりません**（未設定のまま `docker compose up` で動く）。

型チェックも実施。残るのは `--noResolve` 由来の module 未解決と `@types/node` 不在による `process` の警告のみで、`config.ts` は変更前から同じ書き方をしています。

## 触っていないもの

- **`FIREBASE_PROJECT_ID`** — 同じ形（`demo-synthify` の既定値）ですが、消費側が別なので別の変更にします
- **`SYNTHIFY_ADMIN_USER_EMAILS`** — 空の既定値は維持。空は「欠落」ではなく **fail-closed する有効な状態**です（Terraform 側のコメントにもそうあります）

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_