### PR TITLE
ci(web): drop SKIP_ENV_VALIDATION, which nothing reads

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -14,7 +14,6 @@ on:
 # they drifted: three emulator variables only ever existed in compose. Jobs that
 # need them derive them with scripts/compose-browser-env.sh.
 env:
-  SKIP_ENV_VALIDATION: true
   STRIPE_SECRET_KEY: sk_test_e2e_dummy
   STRIPE_PRO_PRICE_ID_JPY: price_e2e_dummy_jpy
 
@@ -196,8 +195,6 @@ jobs:
   monitor-screenshots:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    env:
-      SKIP_ENV_VALIDATION: true
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
> **stacked PR**: base は #37（#38 マージ済みの状態）。差分は `web.yml` の 2 行削除のみ。

環境設定の責務を決める作業の **B**（G2 の掃除）。

## なぜ

`SKyIP_ENV_VALIDATION` は `web.yml` の 2 箇所で設定されていますが、**リポジトリのどこからも読まれていません**。`apps/`・`internal/`・`scripts/`・各種設定ファイルを検索して参照ゼロ。create-t3-app の慣習として名前だけ持ち込まれ、配線されなかったものです。

**ドキュメントとしても無害ではありません。実態と逆のことを言っているからです。** `apps/web/src/config/env.ts:31` は `rawEnvSchema.parse()` を無条件に呼ぶので、CI でもブラウザ env は**常に厳格に検証されています**。ワークフローだけ読むと「CI では検証を切ってある」と読めてしまいます。

## 実装ではなく除去にした理由

「CI で検証を切る」スイッチは、このリポジトリが今まさに明文化した原則と逆を向いています。必須値の欠落は大きな音を立てて落ちるべきで、**CI はそれが最も起きてほしい場所**です（`docs/architecture/environment-variables.md` の原則5）。

## 検証

- リポジトリ全体で `SKIP_ENV_VALIDATION` の出現が **0 件**になったことを確認
- `web.yml` の YAML パース、ワークフロー env に `STRIPE_*` の 2 件だけが残ること、`monitor-screenshots` から空になった `env:` キーごと除去されたことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_