### PR TITLE
ci(deploy): take the GCP target from tfvars, not GitHub Variables

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -24,8 +24,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     # Resolve env from manual input, else from the pushed branch name.
-    # The GitHub Environment scopes secrets/vars so the same names resolve
-    # to per-env values (GCP_WIF_*, GCP_PROJECT_ID, GCP_REGION, ...).
+    # The GitHub Environment scopes the deploy credentials (GCP_WIF_*) and the
+    # values that cannot live in the repository. Where the target is — project
+    # id, region — comes from tfvars instead; see the resolve step below.
     environment: ${{ github.event.inputs.environment || github.ref_name }}
     permissions:
       contents: read
@@ -56,10 +57,21 @@ jobs:
         with:
           terraform_version: 1.6.6
 
+      # project id / region は tfvars が持つ。GitHub Variables に同じ事実を置くと、
+      # リポジトリを読んでも実効値が分からず、compose と web.yml が離れたのと同じ
+      # ずれ方をする。docs/architecture/environment-variables.md の原則3。
+      - name: Resolve GCP target from tfvars
+        run: |
+          set -euo pipefail
+          {
+            echo "GCP_PROJECT_ID=$(bash scripts/tfvar.sh "${ENVIRONMENT}" project_id)"
+            echo "GCP_REGION=$(bash scripts/tfvar.sh "${ENVIRONMENT}" region)"
+          } >> "$GITHUB_ENV"
+
       - name: Resolve image registry
         id: registry
         run: |
-          REGISTRY="${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/synthify-${ENVIRONMENT}"
+          REGISTRY="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/synthify-${ENVIRONMENT}"
           echo "registry=${REGISTRY}" >> "$GITHUB_OUTPUT"
           echo "sha_tag=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
           echo "api_image=${REGISTRY}/api:${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
@@ -77,7 +89,7 @@ jobs:
       # otherwise just re-asserts versioning/lifecycle. Also (re)writes
       # terraform/backend/<env>.hcl that the init step below consumes.
       - name: Ensure Terraform state bucket
-        run: bash scripts/bootstrap-tfstate.sh "${ENVIRONMENT}" "${{ vars.GCP_PROJECT_ID }}" "${{ vars.GCP_REGION }}"
+        run: bash scripts/bootstrap-tfstate.sh "${ENVIRONMENT}" "${GCP_PROJECT_ID}" "${GCP_REGION}"
 
       - name: Terraform init
         working-directory: ${{ env.TF_DIR }}
@@ -114,7 +126,7 @@ jobs:
                    stripe-webhook-secret new-relic-license-key internal-worker-token \
                    gemini-api-key; do
             name="synthify-${s}"
-            existing=$(gcloud secrets versions list "$name" --project "${{ vars.GCP_PROJECT_ID }}" --format="value(name)" --limit=1 2>/dev/null || echo "")
+            existing=$(gcloud secrets versions list "$name" --project "${GCP_PROJECT_ID}" --format="value(name)" --limit=1 2>/dev/null || echo "")
             if [ -z "$existing" ]; then
               echo "::error::secret $name has no version — populate it before deploying"
               missing+=("$name")
@@ -157,11 +169,11 @@ jobs:
 
       - name: Apply DB migrations
         env:
-          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
         run: bash scripts/apply-db-migrations.sh
 
       - name: Configure Docker
-        run: gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev --quiet
+        run: gcloud auth configure-docker ${GCP_REGION}-docker.pkg.dev --quiet
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -225,13 +237,9 @@ jobs:
       # are created/updated with the exact SHA-tagged images. api_base_url
       # stays empty here; it is reconciled in Pass 3.
       #
-      # allowed_user_emails: only override when the GitHub Environment var
-      # is set. If unset we omit the -var so the tfvars fallback wins
-      # (an empty -var would blank out the stage lockdown).
       - name: Terraform apply (full)
         working-directory: ${{ env.TF_DIR }}
         env:
-          ALLOWED_USER_EMAILS: ${{ vars.ALLOWED_USER_EMAILS }}
           STRIPE_PRO_PRICE_ID_JPY: ${{ vars.STRIPE_PRO_PRICE_ID_JPY }}
           STRIPE_PRO_PRICE_ID_USD: ${{ vars.STRIPE_PRO_PRICE_ID_USD }}
           NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
@@ -256,16 +264,12 @@ jobs:
             -var="new_relic_browser_app_name=${NEW_RELIC_BROWSER_APP_NAME}"
             -var="discord_alert_webhook_url=${DISCORD_ALERT_WEBHOOK_URL}"
           )
-          if [ -n "${ALLOWED_USER_EMAILS}" ]; then
-            args+=(-var="allowed_user_emails=${ALLOWED_USER_EMAILS}")
-          fi
           terraform apply "${args[@]}"
 
       # --- Pass 3: feed the API URL back so the worker can call it.
       - name: Terraform apply (wire api_base_url)
         working-directory: ${{ env.TF_DIR }}
         env:
-          ALLOWED_USER_EMAILS: ${{ vars.ALLOWED_USER_EMAILS }}
           STRIPE_PRO_PRICE_ID_JPY: ${{ vars.STRIPE_PRO_PRICE_ID_JPY }}
           STRIPE_PRO_PRICE_ID_USD: ${{ vars.STRIPE_PRO_PRICE_ID_USD }}
           NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
@@ -292,9 +296,6 @@ jobs:
             -var="new_relic_browser_app_name=${NEW_RELIC_BROWSER_APP_NAME}"
             -var="discord_alert_webhook_url=${DISCORD_ALERT_WEBHOOK_URL}"
           )
-          if [ -n "${ALLOWED_USER_EMAILS}" ]; then
-            args+=(-var="allowed_user_emails=${ALLOWED_USER_EMAILS}")
-          fi
           terraform apply "${args[@]}"
 
       - name: Outputs
@@ -312,8 +313,8 @@ jobs:
           set -euo pipefail
           service_json="$(mktemp)"
           gcloud run services describe "synthify-worker-${ENVIRONMENT}" \
-            --project "${{ vars.GCP_PROJECT_ID }}" \
-            --region "${{ vars.GCP_REGION }}" \
+            --project "${GCP_PROJECT_ID}" \
+            --region "${GCP_REGION}" \
             --format=json \
             > "$service_json"
 

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -76,16 +76,27 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
 
+      # project id / region は tfvars が持つ。GitHub Variables に同じ事実を置くと、
+      # リポジトリを読んでも実効値が分からず、compose と web.yml が離れたのと同じ
+      # ずれ方をする。docs/architecture/environment-variables.md の原則3。
+      - name: Resolve GCP target from tfvars
+        run: |
+          set -euo pipefail
+          {
+            echo "GCP_PROJECT_ID=$(bash scripts/tfvar.sh "${ENVIRONMENT}" project_id)"
+            echo "GCP_REGION=$(bash scripts/tfvar.sh "${ENVIRONMENT}" region)"
+          } >> "$GITHUB_ENV"
+
       - name: Deploy Firestore rules
         run: |
           bunx firebase-tools@13 deploy --only firestore:rules --non-interactive \
-            --project ${{ vars.GCP_PROJECT_ID }}
+            --project ${GCP_PROJECT_ID}
 
       - name: Deploy to Firebase Hosting
         run: |
           set -o pipefail
           bunx firebase-tools@13 deploy --only hosting --non-interactive --json \
-            --project ${{ vars.GCP_PROJECT_ID }} \
+            --project ${GCP_PROJECT_ID} \
             | tee /tmp/firebase-deploy.json
 
       - name: Resolve Firebase Hosting URL
@@ -103,7 +114,7 @@ jobs:
             ' /tmp/firebase-deploy.json
           )"
           if [ -z "$FRONTEND_URL" ]; then
-            FRONTEND_URL="https://${{ vars.GCP_PROJECT_ID }}.web.app"
+            FRONTEND_URL="https://${GCP_PROJECT_ID}.web.app"
           fi
           echo "FRONTEND_URL=${FRONTEND_URL}" >> "$GITHUB_ENV"
           echo "Resolved Firebase Hosting URL: ${FRONTEND_URL}"

--- a/scripts/tfvar.sh
+++ b/scripts/tfvar.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Print a single value from terraform/tfvars/<env>.tfvars.
+#
+# tfvars is where non-secret stage/prod configuration lives, and it is reviewable
+# in the repository. Deploy workflows used to restate some of the same facts as
+# GitHub Environment Variables — project id and region existed in both — which
+# meant the effective value could not be known by reading the repository, and
+# the two could drift the way compose and web.yml did.
+#
+# Usage: scripts/tfvar.sh stage project_id
+set -euo pipefail
+
+env_name="${1:?usage: tfvar.sh <env> <key>}"
+key="${2:?usage: tfvar.sh <env> <key>}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+file="${repo_root}/terraform/tfvars/${env_name}.tfvars"
+
+if [ ! -f "$file" ]; then
+  echo "no tfvars for environment '${env_name}' (${file})" >&2
+  exit 1
+fi
+
+# Only plain `key = "value"` assignments. Anything else (a list, an
+# interpolation) is out of scope on purpose: this exists to read the handful of
+# scalars the deploy pipeline needs before Terraform runs, not to parse HCL.
+value="$(sed -nE "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*\"([^\"]*)\".*/\1/p" "$file" | head -n 1)"
+
+if [ -z "$value" ]; then
+  echo "key '${key}' not found in ${file}" >&2
+  exit 1
+fi
+
+printf '%s\n' "$value"


### PR DESCRIPTION
環境設定の責務を決める作業の **D**（原則3「非秘密の stage/prod 設定は tfvars に置く」）。`main` ベースなので #36〜#39 とは独立にマージできます。

## なぜ

デプロイの宛先（プロジェクトとリージョン）が**2箇所で宣言**されていました。

| 事実 | tfvars | GitHub Variables |
|---|---|---|
| プロジェクト | `project_id` | `vars.GCP_PROJECT_ID` |
| リージョン | `region` | `vars.GCP_REGION` |

Terraform は前者を、gcloud / docker の全ステップは後者を読みます。両者を一致させる仕組みは無く、**リポジトリを読んでも実効値が分かりません**。compose と web.yml がずれて CI 製バンドルが実 Firebase を向いたのと同じ構図です。

レビュー可能なのは tfvars なので、そちらを正とします。

## 変更内容

`scripts/tfvar.sh` が `terraform/tfvars/<env>.tfvars` からスカラーを読み、ステップが project id / region を環境に置きます。**10 箇所の呼び出し**がそれを使うようになりました。

**`allowed_user_emails` の override を撤去**しました。従来は GitHub Variable が設定されているときだけ `-var` を渡し、無ければ tfvars がフォールバックする作りで、**stage のアカウント制限に供給元が2つあり、リポジトリはその片方しか見せていませんでした**。今後は tfvars のみ。変更が設定画面の編集ではなくコミットになりますが、**アクセス制御リストが可視でレビュー可能になる価値のほうが上**だと判断しました（ご承認いただいた方針です）。

## 現在の値が一致していることの根拠

GitHub Variables の値は私からは読めませんが、**パイプラインが通っている事実が一致を示しています**。

- Terraform は tfvars のプロジェクトに secret を作り、secret ゲートは GitHub Variable のプロジェクトを見に行き、**見つかっています**
- イメージは Variable から組んだレジストリ名に push され、そのレジストリを Terraform は tfvars のリージョンで管理しています

不一致なら、いずれもとっくに失敗しているはずです。

参考までに tfvars の現在値: stage = `synthify-stage-491705` / `asia-northeast1` / `allowed_user_emails = "korokororin47@gmail.com"`、prod = `synthify-491705` / `asia-northeast1`。**GitHub 側で許可メールを追加していた場合、その人はこの PR で締め出されます** — マージ前にご確認ください。

## 検証

デプロイは実行できないので、確認できたのは以下です。

- `scripts/tfvar.sh` を stage / prod × `project_id` / `region` で実行し、期待値が取れること
- 未知のキー・未知の環境で**終了コード 1**（タイポが空のプロジェクト ID に解決されず、デプロイが止まる）
- 両ワークフローの YAML パース、`vars.GCP_PROJECT_ID` / `vars.GCP_REGION` の残存が **0 件**、`ALLOWED_USER_EMAILS` の残存が **0 件**
- override 撤去後も Pass 2 / Pass 3 の `args=(...)` が壊れていないこと

実態と合わなくなった 2 つのコメント（「GitHub Environment が GCP_PROJECT_ID/REGION を解決する」「GitHub Variable があれば override」）も更新・削除しました。

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_