### PR TITLE
ci(deploy): assert the shipped bundle carries no test hooks

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -79,6 +79,17 @@ jobs:
       # project id / region は tfvars が持つ。GitHub Variables に同じ事実を置くと、
       # リポジトリを読んでも実効値が分からず、compose と web.yml が離れたのと同じ
       # ずれ方をする。docs/architecture/environment-variables.md の原則3。
+      # apps/web は Playwright が実セッションを作るために window.__synthifyE2E を
+      # 生やす。アプリ唯一のログイン導線は Google OAuth でテストランナーには踏めず、
+      # このフックがエミュレータの email/password 経路への唯一の橋渡しになっている。
+      # 開発中は妥当だが、出荷されるバンドルに入ってはいけない。
+      #
+      # firebase.ts は NODE_ENV === 'development' で囲い、コメントで「本番バンドルに
+      # 入ることはない」と宣言しているが、これまで誰も確認していなかった。意図では
+      # なく成果物の性質にする。docs/architecture/environment-variables.md の原則4。
+      - name: Assert no test hooks in the bundle
+        run: bash scripts/assert-no-test-hooks.sh apps/web/out
+
       - name: Resolve GCP target from tfvars
         run: |
           set -euo pipefail

--- a/scripts/assert-no-test-hooks.sh
+++ b/scripts/assert-no-test-hooks.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Fail if a built artifact contains a test-only affordance.
+#
+# apps/web exposes window.__synthifyE2E so Playwright can establish a real
+# Firebase session — the app's only sign-in path is Google OAuth, which a test
+# runner cannot drive, so the hook is the bridge to the emulator's
+# email/password path. It signs a user in from anything that can reach the
+# global, which is fine in development and unacceptable in a deployed bundle.
+#
+# firebase.ts gates it on NODE_ENV === 'development' and its comment states the
+# hook "is never present in a production bundle/environment". That was an
+# intention with nothing checking it. This makes it a property of the artifact.
+#
+# Usage: scripts/assert-no-test-hooks.sh apps/web/out
+set -euo pipefail
+
+root="${1:?usage: assert-no-test-hooks.sh <build-output-dir>}"
+
+if [ ! -d "$root" ]; then
+  echo "no build output at ${root}" >&2
+  exit 1
+fi
+
+# Property names reached through a global object survive minification, so a
+# literal search is enough — the bundler cannot rename window.__synthifyE2E
+# without breaking the caller it was written for.
+markers=(
+  __synthifyE2E
+)
+
+failed=0
+for marker in "${markers[@]}"; do
+  # -r over the whole tree: the hook could land in any chunk, and which chunk is
+  # a build detail that must not be part of this check.
+  if hits="$(grep -rl --binary-files=without-match -- "$marker" "$root" 2>/dev/null)" && [ -n "$hits" ]; then
+    echo "::error::test hook '${marker}' found in the build output" >&2
+    printf '  %s\n' $hits >&2
+    failed=1
+  fi
+done
+
+if [ "$failed" -ne 0 ]; then
+  cat >&2 <<'EOF'
+
+This artifact is about to be deployed. A test hook in it means the gate that is
+supposed to keep it out of shipped builds did not hold — check NODE_ENV at build
+time and the condition in apps/web/src/lib/firebase.ts before releasing.
+EOF
+  exit 1
+fi
+
+echo "no test hooks in ${root}"


### PR DESCRIPTION
> **stacked PR**: base は #40（同じ `deploy-frontend.yml` を触るため）。差分はスクリプト 1 本とステップ 1 つ。

環境設定の責務を決める作業の **E**（原則4「ビルド成果物に、その環境に属さないものを入れない」の強制）。これで A〜E が揃います。

## なぜ

`apps/web` は Playwright が実 Firebase セッションを作るために `window.__synthifyE2E` を生やします。これは**必要に迫られたもの**で、手抜きではありません — アプリ唯一のログイン導線は Google OAuth で、テストランナーには原理的に踏めない。フックがエミュレータの email/password 経路への唯一の橋渡しです。

そして、そのフックは **グローバルに到達できるものなら何からでもユーザーをサインインさせます**。

`firebase.ts` は `NODE_ENV === 'development'` で囲い、コメントで「本番バンドルに入ることはない」と宣言しています。**しかし誰も確認していませんでした。** 保証は「ビルド時に環境変数が正しい値であること」と「後から誰も条件を広げないこと」の2つに乗っているだけで、しかも**破れても見た目には分かりません**（フック入りのバンドルは、無いものと全く同じように動きます）。

コメントの中の意図ではなく、**出荷されるものの性質**にします。

## 変更内容

`scripts/assert-no-test-hooks.sh` が成果物を検査し、`deploy-frontend.yml` の **ビルドとデプロイの間**で走ります。

グローバル経由のプロパティ名は minify を生き延びます（バンドラは `window.__synthifyE2E` を、それを呼ぶ側を壊さずに rename できない）ので、リテラル検索で十分です。

## 検証

`apps/web` はこの環境でビルドできないため、フィクスチャで3ケース確認しました。

| 成果物 | 結果 |
|---|---|
| クリーン（`window.foo` のみ） | `no test hooks in ...` / 終了コード 0 |
| フック混入（`window.__synthifyE2E=...`） | **該当ファイルを列挙して終了コード 1** |
| 出力ディレクトリ不在 | 終了コード 1（デプロイを黙って素通りさせない） |

バイナリファイルを混ぜても誤検知しないこと（`--binary-files=without-match`）も確認済みです。

## #35 との関係

**意図的に独立させています。** `apps/web` に「e2e 用ビルドではフックを入れる」明示的なオプトイン（#35 で保留中の選択肢 A）が入るかどうかに関係なく、この検査は有効です。むしろフラグが入るなら**この検査の重要性は上がります** — それがデプロイへの流出を止める最後の砦になるので。

現状の `main` に対しても、いま初めて「本番バンドルにフックが無い」ことが検証されるようになります。

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_