### PR TITLE
fix(deploy): define ENVIRONMENT for the frontend, and fail when it is missing

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -63,9 +63,15 @@ jobs:
       - name: Resolve GCP target from tfvars
         run: |
           set -euo pipefail
+          # Assign first, write second. Inside `echo "K=$(...)"` a failing
+          # substitution still leaves echo returning 0, so the step succeeds and
+          # writes an empty value — which is how a broken ENVIRONMENT surfaced
+          # three steps later as "--project argument missing" instead of here.
+          project_id="$(bash scripts/tfvar.sh "${ENVIRONMENT}" project_id)"
+          region="$(bash scripts/tfvar.sh "${ENVIRONMENT}" region)"
           {
-            echo "GCP_PROJECT_ID=$(bash scripts/tfvar.sh "${ENVIRONMENT}" project_id)"
-            echo "GCP_REGION=$(bash scripts/tfvar.sh "${ENVIRONMENT}" region)"
+            echo "GCP_PROJECT_ID=${project_id}"
+            echo "GCP_REGION=${region}"
           } >> "$GITHUB_ENV"
 
       - name: Resolve image registry

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -30,6 +30,12 @@ jobs:
     permissions:
       contents: read
       id-token: write
+
+    # `environment:` above is the GitHub Environment — it scopes secrets, it is
+    # not a shell variable. Steps that need the environment name need this.
+    env:
+      ENVIRONMENT: ${{ github.event.inputs.environment || github.ref_name }}
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,9 +88,15 @@ jobs:
       - name: Resolve GCP target from tfvars
         run: |
           set -euo pipefail
+          # Assign first, write second. Inside `echo "K=$(...)"` a failing
+          # substitution still leaves echo returning 0, so the step succeeds and
+          # writes an empty value — which is how a broken ENVIRONMENT surfaced
+          # three steps later as "--project argument missing" instead of here.
+          project_id="$(bash scripts/tfvar.sh "${ENVIRONMENT}" project_id)"
+          region="$(bash scripts/tfvar.sh "${ENVIRONMENT}" region)"
           {
-            echo "GCP_PROJECT_ID=$(bash scripts/tfvar.sh "${ENVIRONMENT}" project_id)"
-            echo "GCP_REGION=$(bash scripts/tfvar.sh "${ENVIRONMENT}" region)"
+            echo "GCP_PROJECT_ID=${project_id}"
+            echo "GCP_REGION=${region}"
           } >> "$GITHUB_ENV"
 
       - name: Deploy Firestore rules


### PR DESCRIPTION
**#40 で私が入れた回帰の修正です。** stage の frontend デプロイを壊しました。

## 何が起きたか

[run 30754767656](https://github.com/Keyhole-Koro/Synthify/actions/runs/30754767656):

```
line 3: ENVIRONMENT: unbound variable
GCP_PROJECT_ID: 
GCP_REGION: 
error: option '-P, --project <alias_or_project_id>' argument missing
```

#40 で `deploy-backend.yml` に作った解決ステップを `deploy-frontend.yml` にも移植しましたが、**そちらに `ENVIRONMENT` が定義されているか確認していませんでした**。定義されていません。29行目の `environment:` は GitHub Environment（secrets のスコープ指定）であって、シェル変数ではない。backend には job レベルの `env:` ブロックがありますが、frontend には今回まで必要が無かったため存在しませんでした。

## より悪いのは後半です

ステップを `echo "GCP_PROJECT_ID=$(...)"` と書いていました。**`echo` の引数の中でコマンド置換が失敗しても、`echo` 自体は成功します。** 結果:

- ステップは **exit 0**
- `$GITHUB_ENV` に **空の値**が書き込まれる
- デプロイは続行し、**3ステップ先の firebase** が「`--project` の引数が無い」と言って落ちる

原因を全く指していないエラーで、しかも途中まで進んでしまう。**`docs/architecture/environment-variables.md` が扱っている失敗モードそのものを、それを適用するための変更で再導入していました。**

## 修正

1. `deploy-frontend.yml` に job レベルの `ENVIRONMENT` を定義
2. **両方の**ワークフローで、変数に代入してから書き出す形に変更し、`set -e` が失敗を捕まえるようにする

backend も同じ構文でした。あちらは `ENVIRONMENT` がたまたま定義されているから症状が出ていないだけなので、一緒に直します。

## 検証

stage を壊したのと**同一条件**（`ENVIRONMENT` 未定義）で両方の書き方を実行しました。

| | 終了コード | `$GITHUB_ENV` に書かれた値 |
|---|---|---|
| 旧（`echo "K=$(...)"`） | **0** | `GCP_PROJECT_ID=` ← 空を書いて続行 |
| 新（代入してから書き出し） | **1** | なし ← その場で停止 |

`ENVIRONMENT=stage` では新形も exit 0 で `synthify-stage-491705` を解決します。両ファイルの YAML パースと、`ENVIRONMENT` が両 job の env に存在することも確認済みです。

## backend の失敗は別件です

同じ push で backend も落ちていますが、**そちらはこの回帰とは無関係**で、しかも過去最良の到達点です。monitor イメージのビルドが初めて通り、`Terraform apply (full)` まで進んで、monitor の Cloud Run サービスと New Relic アラート群の作成にも成功。落ちたのは最後の1リソース、`stage.monitor.synthify.keyhole.work` のドメイン所有権が GCP 側で未検証、というものです。こちらは別途対応が要ります。

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_