### PR TITLE
chore(terraform): drop the monitor custom domain until the domain is verified

### DIFF
--- a/terraform/tfvars/prod.tfvars
+++ b/terraform/tfvars/prod.tfvars
@@ -4,7 +4,13 @@ environment  = "prod"
 web_base_url = "https://synthify.keyhole.work"
 
 # monitor ダッシュボードのカスタムドメイン (scheme なしのホスト名)。
-monitor_domain = "monitor.synthify.keyhole.work"
+# 空 => ドメインマッピングを作らず、Cloud Run の run.app URL を使う。
+#
+# stage と同じ理由で一時的に空にしている (詳細は stage.tfvars)。prod はまだ
+# monitor をデプロイしていないが、ドメイン所有権の検証は keyhole.work 単位なので
+# 未検証のまま流せば同じ地点で止まる。先に踏まないようにしておく。
+monitor_domain = ""
+# monitor_domain = "monitor.synthify.keyhole.work"
 
 # CI/WIF SA that runs terraform apply (GCP_WIF_SA_EMAIL). Needs actAs on
 # the api/worker runtime SAs to attach them to Cloud Run.

--- a/terraform/tfvars/stage.tfvars
+++ b/terraform/tfvars/stage.tfvars
@@ -4,7 +4,19 @@ environment  = "stage"
 web_base_url = "https://stage.synthify.keyhole.work"
 
 # monitor ダッシュボードのカスタムドメイン (scheme なしのホスト名)。
-monitor_domain = "stage.monitor.synthify.keyhole.work"
+# 空 => ドメインマッピングを作らず、Cloud Run の run.app URL を使う。
+#
+# 一時的に空にしている。stage.monitor.synthify.keyhole.work の所有権が GCP 側で
+# 未検証で、DomainMapping の作成が "Caller is not authorized to administer the
+# domain" で失敗し、デプロイ全体がそこで止まっていた。ダッシュボード自体は
+# run.app URL で動くので、検証を待つ間デプロイを止める理由がない。
+#
+# 戻す手順: Search Console で keyhole.work の所有権を検証し、デプロイに使う
+# サービスアカウントを所有者に追加してから、下の値を復帰させて再デプロイする。
+# その後 `terraform output monitor_dns_records` が返す CNAME を Cloudflare に
+# 追加する (プロキシは DNS only にすること)。
+monitor_domain = ""
+# monitor_domain = "stage.monitor.synthify.keyhole.work"
 
 # Lock stage to a single account. CD overrides this with the GitHub
 # Environment variable ALLOWED_USER_EMAILS when set; this value is the


### PR DESCRIPTION
止まっている stage のデプロイを完走させるための一時措置です。`main` ベースで独立にマージできます。

## なぜ

stage のデプロイが**初めて `Terraform apply (full)` に到達し、その大半が成功しました**（[run 30754767675](https://github.com/Keyhole-Koro/Synthify/actions/runs/30754767675)）。

- New Relic のアラート群 — 作成完了
- **`synthify-monitor-stage` の Cloud Run サービス — 作成完了**
- api / worker / eval — 更新完了

落ちたのは最後の1リソースだけです:

```
Error waiting to create DomainMapping: resource is in failed state "Ready:False",
Caller is not authorized to administer the domain stage.monitor.synthify.keyhole.work.
```

Cloud Run は、プロジェクトが所有権を検証していないドメインにはマッピングを作りません。この検証は Search Console でのブラウザ作業（`keyhole.work` を追加 → TXT で証明 → デプロイ用サービスアカウントを所有者に追加）で、**このリポジトリの中身とは無関係**です。

その間 stage は「**DB は 0021〜0024 適用済み、Cloud Run は旧コード**」のまま放置されています。apply 全体がこのリソースで止まるためです。

ダッシュボードにドメインは要りません。モジュールは既に空値を「マッピングを作らず run.app URL を使う」と解釈します（`count = var.domain == "" ? 0 : 1`）。**きれいなホスト名と、デプロイが完走する環境を天秤にかければ、後者が先**です。

## 変更内容

`stage.tfvars` と `prod.tfvars` の `monitor_domain` を空に。**元の値は直上にコメントとして残し、復帰手順（Search Console での検証 → 値を戻す → `terraform output monitor_dns_records` の CNAME を Cloudflare に追加、プロキシは DNS only）も併記**しました。放棄ではなく先送りだと読めるようにしてあります。

prod も空にしています。まだ monitor をデプロイしていませんが、**所有権の検証はドメイン単位**なので、未検証のまま流せば同じ地点で止まります。先に踏まないようにしておく意図です。

## 検証

- 変更後の `monitor_domain` が両環境で空になっていること
- `scripts/tfvar.sh` が `project_id` / `region` を従来どおり読めること（#40 が依存しているため）
- コメントアウトした旧値の行を `tfvar.sh` が誤って拾わないこと（`#` 始まりの行は正規表現にマッチしない）

## 次の apply についての注意

失敗したドメインマッピングが、**stage の Terraform state に残っているか、GCP 側に `Ready:False` のまま残っている可能性**があります。Terraform が保持していればこの変更で destroy されますが、保持していなければ手動削除が要るかもしれません。次の apply のログで確認できます。

---
_Generated by [Claude Code](https://claude.ai/code/session_0169tV8Z7SEAVuQgdAr8es54)_