### PR TITLE
fix(e2e): run the nightly checks against the deployed target only

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -21,6 +21,16 @@ jobs:
       # the note in web.yml.
       - working-directory: apps/web
         run: bun run playwright:install
+      # Without a target the run silently degrades into a localhost check that
+      # boots the whole compose stack and then times out, so stop here instead.
+      - name: Require a deployed target
+        env:
+          E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}
+        run: |
+          if [ -z "$E2E_BASE_URL" ]; then
+            echo "::error::E2E_BASE_URL is not set; the nightly external checks have no deployed environment to run against."
+            exit 1
+          fi
       - name: Run explicitly tagged external checks
         working-directory: apps/web
         env:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ bun run e2e:last
 bun run e2e:report
 bun run e2e:pr       # Chromiumの通常suite（外部サービス非依存）
 bun run e2e:repeat5  # flaky確認用に同じsuiteを5回反復
-bun run e2e:nightly  # @nightly の外部統合確認だけ
+bun run e2e:nightly  # デプロイ済み環境への外部統合確認だけ
+```
+
+`e2e:nightly` はデプロイ済み環境を対象にするので、`E2E_BASE_URL` の指定が必須です。指定するとローカルのCompose環境は起動せず、Auth emulatorに依存する認証setupも実行しません。
+
+```bash
+E2E_BASE_URL=https://example.invalid bun run e2e:nightly
 ```
 
 失敗時のHTML reportにはtrace、screenshot、videoに加えて、browser console、page error、失敗した通信、4xx/5xx response、テスト開始後のComposeログが添付されます。認証tokenや共有tokenは診断出力でマスクされます。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,7 @@
     "e2e:last": "playwright test --last-failed --workers=1",
     "e2e:pr": "playwright test --project=chromium --grep-invert @nightly",
     "e2e:repeat5": "playwright test --project=chromium --repeat-each=5",
-    "e2e:nightly": "playwright test --project=chromium --grep @nightly",
+    "e2e:nightly": "playwright test --project=nightly",
     "e2e:report": "playwright show-report",
     "playwright:install": "playwright install --with-deps chromium",
     "generate:firestore-types": "node ../../scripts/generate-firestore-types.mjs",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -10,7 +10,11 @@ function localFrontendPort(): string {
   }
 }
 
-const baseURL = process.env.E2E_BASE_URL ?? `http://localhost:${localFrontendPort()}`;
+// Set only by the nightly job, which points at a deployed environment. Its
+// presence is what switches the run from "boot the local stack" to "test what
+// is already running out there".
+const externalBaseURL = process.env.E2E_BASE_URL;
+const baseURL = externalBaseURL ?? `http://localhost:${localFrontendPort()}`;
 const authFile = fileURLToPath(new URL('./e2e/.auth/user.json', import.meta.url));
 // Gate webServer readiness on the API, not the frontend: Next dev answers
 // within seconds while the Go backend builds for minutes on a cold cache,
@@ -38,14 +42,27 @@ export default defineConfig({
     { name: 'setup', testMatch: /auth\.setup\.ts/ },
     {
       name: 'chromium',
+      testIgnore: /nightly\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
         storageState: authFile,
       },
       dependencies: ['setup'],
     },
+    // The nightly checks hit a deployed environment, where there is no Auth
+    // emulator: they get their own project so they skip the auth setup, which
+    // mints its test user against 127.0.0.1:9099 and dies on a refused
+    // connection. Selecting only the nightly specs does not avoid it — a
+    // dependency project runs whatever --grep leaves in the projects it feeds.
+    {
+      name: 'nightly',
+      testMatch: /nightly\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
   ],
-  webServer: process.env.E2E_REUSE_SERVER
+  // A deployed target needs no local stack, and booting one only burns five
+  // minutes waiting for a health endpoint the tests never call.
+  webServer: externalBaseURL || process.env.E2E_REUSE_SERVER
     ? undefined
     : {
         // Build the only local image explicitly: Compose v5's bake path is


### PR DESCRIPTION
The nightly job has failed every night since it was added — 16 scheduled
runs, none green. Playwright still booted the local Compose stack even
though the run targets E2E_BASE_URL, and that stack cannot come up in this
workflow. The frontend container exits on "ln: Permission denied" because
the runner's checkout is uid 1001 while the container runs as LOCAL_UID
(1000, unset here), and the API exits on "stripe provider init: billing
provider is not configured" because the dummy Stripe env web.yml sets is
absent. The job then waited out the 300s webServer timeout.

Booting anything locally was the wrong shape for these checks, so drop it
instead of copying web.yml's workarounds over:

- Skip webServer whenever E2E_BASE_URL is set; a deployed target needs no
  local stack.
- Give the nightly specs their own project. They previously ran under
  chromium, which depends on the auth setup — and that setup creates its
  user through the Firebase Auth emulator on 127.0.0.1:9099, so against a
  deployed environment it fails on a refused connection before any nightly
  test starts. Narrowing to @nightly did not skip it; a dependency project
  runs regardless.
- Fail the job fast when E2E_BASE_URL is missing, rather than silently
  degrading into a localhost run.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HaYpjFxvztJCQVLo3tvJ83