### PR TITLE
chore(ops): add a secret cleanup script and scope the CI alert ticket

### DIFF
--- a/issues/tickets/ci-cd-failure-alerts.md
+++ b/issues/tickets/ci-cd-failure-alerts.md
@@ -1,0 +1,42 @@
+# CI/CD失敗通知の動作確認と運用ドキュメント整備
+
+## 背景
+
+CI/CD失敗をDiscordへ通知する仕組みは実装済み。reusable workflow (`.github/workflows/notify-discord.yml`) が用意され、以下のワークフローから `if: failure()` で呼ばれている。
+
+- `web.yml` (`needs: [checks, binaries, e2e]`)
+- `backend.yml` (`needs: [build, terraform]`)
+- `deploy-frontend.yml` (`needs: deploy`)
+- `deploy-backend.yml` (`needs: deploy`)
+
+通知内容はワークフロー名・job名・ブランチ/PR番号・commit SHA・actor・Actions実行画面へのリンクを含む。webhook URLは `DISCORD_WEBHOOK_URL` として登録済み。
+
+残っているのは「本当に届くかの検証」と「届いた後に誰が何をするかの記述」の2点。通知が飛ばない設定ミスは、実際に失敗させるまで気づけない。
+
+なお本番稼働中のアプリケーション異常については [application-monitoring-alerts.md](./application-monitoring-alerts.md) が別途扱う(通知先も `DISCORD_ALERT_WEBHOOK_URL` で分離されている)。
+
+## 残タスク
+
+### 1. 通知が実際に届くことを確認する
+
+- [ ] 意図的にテストを失敗させたPRを立て、Discordに通知が届くことを確認する
+- [ ] 通知メッセージから失敗箇所(どのワークフロー/どのjob/どのcommit)が一目で分かることを確認する
+- [ ] 成功時には通知が飛ばないことを確認する(`if: failure()` の設定ミスがないか)
+- [ ] 4ワークフローすべてで確認する。特に `deploy-backend.yml` / `deploy-frontend.yml` は
+      `needs: deploy` のみのため、deploy job より前段で失敗した場合に通知されるかを確認する
+
+### 2. アラート運用ドキュメントを整備する
+
+現状、通知が届いた後の扱いがどこにも書かれていない。[docs/architecture/cloud-logging-runbook.md](../../docs/architecture/cloud-logging-runbook.md) にログ調査手順はあるが、CI/CD失敗通知からの導線がない。
+
+- [ ] 通知を受けたら誰が対応するかを明記する
+- [ ] 一次対応の手順(Actions実行画面の確認 → 再実行するか調査するかの判断基準)を書く
+- [ ] main が壊れている場合のエスカレーション/revert方針を書く
+- [ ] flaky test で通知が繰り返し飛ぶ場合の扱いを決める(通知疲れを防ぐ)
+- [ ] 置き場所は README か CONTRIBUTING か runbook 配下かを決めて追記する
+
+## 完了条件
+
+- [ ] 4ワークフローすべてで失敗時にDiscord通知が届くことを確認済み
+- [ ] 成功時に誤通知が飛ばないことを確認済み
+- [ ] 通知を受けた人が次に何をすべきかがドキュメントから辿れる

--- a/scripts/cleanup-secrets.sh
+++ b/scripts/cleanup-secrets.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/cleanup-secrets.sh <project-id>
+# This script keeps the latest version of every secret in the project and destroys all older versions.
+
+set -euo pipefail
+
+PROJECT_ID="${1:-}"
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "Usage: $0 <project-id>"
+  exit 1
+fi
+
+echo "Scanning for secrets in project: $PROJECT_ID..."
+SECRETS=$(gcloud secrets list --project="$PROJECT_ID" --format="value(name)")
+
+for secret in $SECRETS; do
+  echo "Checking secret: $secret"
+  
+  # Get all enabled/disabled versions sorted by version number descending (latest first)
+  ALL_VERSIONS=$(gcloud secrets versions list "$secret" --project="$PROJECT_ID" \
+    --filter="state:enabled OR state:disabled" \
+    --sort-by="~name" \
+    --format="value(name)")
+  
+  # Count how many active versions exist
+  VERSION_COUNT=$(echo "$ALL_VERSIONS" | grep -c . || true)
+  
+  if [[ "$VERSION_COUNT" -le 1 ]]; then
+    echo "  -> Only $VERSION_COUNT active version. Skipping."
+    continue
+  fi
+  
+  # Extract everything except the first (latest) version
+  OLD_VERSIONS=$(echo "$ALL_VERSIONS" | tail -n +2)
+  
+  for v in $OLD_VERSIONS; do
+    echo "  -> Destroying old version: $v"
+    gcloud secrets versions destroy "$v" --secret="$secret" --project="$PROJECT_ID" --quiet
+  done
+done
+
+echo "Done!"


### PR DESCRIPTION
Two unrelated ops leftovers that were sitting untracked in my working copy, split into one commit each.

## `scripts/cleanup-secrets.sh`

Keeps the latest version of every secret in a GCP project and destroys the older enabled/disabled ones, so stale versions stop accumulating. Takes the project id as an argument and refuses to run without it. Committed with the executable bit set.

## `issues/tickets/ci-cd-failure-alerts.md`

The ticket as originally drafted asked for work that has since shipped — `notify-discord.yml` exists as a reusable workflow, and `web.yml`, `backend.yml`, `deploy-frontend.yml`, and `deploy-backend.yml` all call it under `if: failure()` with the workflow/job/branch/SHA/actor/run-URL payload it specified.

Two items from it are genuinely still open, so the ticket is rescoped to those rather than deleted:

- nobody has confirmed the notifications actually fire (a misconfigured `if: failure()` is invisible until something fails)
- there is no doc saying who responds to one — `cloud-logging-runbook.md` covers log investigation but nothing links CI/CD failures to it

Kept as a file because `application-monitoring-alerts.md` links to it by relative path twice.

## Notes

Both files are new and touch no existing code, so there is nothing to run here. The links in the rewritten ticket were checked to resolve in both directions.