### PR TITLE
ci(e2e): take the nightly target from tfvars instead of an unset secret

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -2,6 +2,19 @@ name: E2E External Integration
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployed environment to check
+        type: choice
+        required: true
+        default: stage
+        options:
+          - stage
+          - prod
+      base_url:
+        description: Ad-hoc target URL (overrides the environment's tfvars value)
+        type: string
+        required: false
   schedule:
     - cron: "17 18 * * *"
 
@@ -21,20 +34,34 @@ jobs:
       # the note in web.yml.
       - working-directory: apps/web
         run: bun run playwright:install
+      # The deployed frontend URL is already a fact the repository owns:
+      # tfvars' web_base_url is what Terraform hands the API as the CORS origin
+      # and billing redirect base. Reading it here keeps the nightly target
+      # discoverable by reading the repository — the same reason deploy-*.yml
+      # takes project id / region from tfvars instead of GitHub Variables (see
+      # docs/architecture/environment-variables.md). It also removes the
+      # repository secret this job used to require, which was never set: every
+      # scheduled run since the check landed failed on the missing value.
+      #
       # Without a target the run silently degrades into a localhost check that
-      # boots the whole compose stack and then times out, so stop here instead.
-      - name: Require a deployed target
+      # boots the whole compose stack and then times out, so a failed lookup
+      # must stop the job. Assign first, write second: inside
+      # `echo "K=$(...)"` a failing substitution still leaves echo returning 0,
+      # so the step would succeed and export an empty value.
+      - name: Resolve the deployed target
         env:
-          E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}
+          ENVIRONMENT: ${{ inputs.environment || 'stage' }}
+          BASE_URL_INPUT: ${{ inputs.base_url }}
         run: |
-          if [ -z "$E2E_BASE_URL" ]; then
-            echo "::error::E2E_BASE_URL is not set; the nightly external checks have no deployed environment to run against."
-            exit 1
+          set -euo pipefail
+          base_url="${BASE_URL_INPUT:-}"
+          if [ -z "$base_url" ]; then
+            base_url="$(bash scripts/tfvar.sh "${ENVIRONMENT}" web_base_url)"
           fi
+          echo "E2E_BASE_URL=${base_url}" >> "$GITHUB_ENV"
+          echo "Nightly target: ${base_url}"
       - name: Run explicitly tagged external checks
         working-directory: apps/web
-        env:
-          E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}
         run: bun run e2e:nightly
       - if: failure()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ bun run e2e:nightly  # デプロイ済み環境への外部統合確認だけ
 E2E_BASE_URL=https://example.invalid bun run e2e:nightly
 ```
 
+CI (`.github/workflows/e2e-nightly.yml`) は対象URLを `terraform/tfvars/<env>.tfvars` の `web_base_url` から解決します（既定は stage）。手動実行時は環境の選択と、任意のURLでの上書きができます。
+
 失敗時のHTML reportにはtrace、screenshot、videoに加えて、browser console、page error、失敗した通信、4xx/5xx response、テスト開始後のComposeログが添付されます。認証tokenや共有tokenは診断出力でマスクされます。
 
 

--- a/apps/web/e2e/authorization.spec.ts
+++ b/apps/web/e2e/authorization.spec.ts
@@ -4,12 +4,29 @@ import { createTestUser, signInThroughApp } from './helpers/firebase-emulator';
 test('owner invites editor/viewer, changes role, and removes the member', async ({ browser, page }) => {
   test.setTimeout(120_000);
   const member = await createTestUser();
-  const context = await browser.newContext();
+  // storageState has to be cleared explicitly: inside a test, browser.newContext()
+  // inherits the project's `use` options, so a bare newContext() opens already
+  // signed in as the owner — including the Firebase session, which auth.setup
+  // saves out of IndexedDB. That is what made this test flaky. The owner's page
+  // load fired its own SignInUser, waitForResponse matched *that* one, and the
+  // context was closed while the member's provisioning call was still in flight
+  // (the API logged it as 499). InviteMember then found no user for the address
+  // and failed with NotFound, which surfaced ten seconds later as "the invited
+  // email never appeared".
+  const context = await browser.newContext({ storageState: undefined });
   const provisionPage = await context.newPage();
-  await Promise.all([
-    provisionPage.waitForResponse('**/synthify.app.v1.UserService/SignInUser'),
+  // Assert the provisioning call itself: the invite below can only succeed once
+  // the member exists in our database, so a failure belongs here rather than in
+  // a later expectation about the member list.
+  const [provisioned] = await Promise.all([
+    provisionPage.waitForResponse(
+      (response) =>
+        response.url().includes('/synthify.app.v1.UserService/SignInUser') &&
+        response.request().method() === 'POST',
+    ),
     signInThroughApp(provisionPage, member),
   ]);
+  expect(provisioned.ok()).toBeTruthy();
   await expect(provisionPage.getByRole('button', { name: 'ログアウト' })).toBeVisible();
   await context.close();
   await page.goto('/');

--- a/apps/web/e2e/sharing.spec.ts
+++ b/apps/web/e2e/sharing.spec.ts
@@ -30,7 +30,11 @@ test('creates a public read-only link and revokes access', async ({ browser, pag
   const shareURL = (await linkCode.textContent())?.trim();
   expect(shareURL).toBeTruthy();
 
-  const anonymous = await browser.newContext();
+  // Genuinely signed out: browser.newContext() inherits the project's `use`
+  // options inside a test, so without this the "anonymous" viewer would carry
+  // the owner's session and none of the assertions below would be testing what
+  // a link recipient actually sees.
+  const anonymous = await browser.newContext({ storageState: undefined });
   const viewer = await anonymous.newPage();
   await viewer.goto(shareURL!);
   await expect(viewer.getByText('共有リンク · Read-only')).toBeVisible();
@@ -53,7 +57,7 @@ test('creates a public read-only link and revokes access', async ({ browser, pag
 });
 
 test('shows a terminal error for an invalid share token', async ({ browser }) => {
-  const anonymous = await browser.newContext();
+  const anonymous = await browser.newContext({ storageState: undefined });
   const page = await anonymous.newPage();
   await page.goto('/view?token=not-a-valid-share-token');
   await expect(page.getByRole('heading', { name: 'リンクを開けません' })).toBeVisible();


### PR DESCRIPTION
The nightly external checks have failed every scheduled run since the
"require a deployed target" guard landed: they read E2E_BASE_URL from a
repository secret that was never set, so the job stopped at that guard
without running a single check.

The URL is not missing information — tfvars already owns it. web_base_url
is what Terraform hands the API as its CORS origin and billing redirect
base, so it is the deployed frontend by construction. Resolve it with
scripts/tfvar.sh, the same way deploy-*.yml resolves project id and
region, and the effective target stays readable from the repository
(docs/architecture/environment-variables.md, principle 3).

Manual runs can pick the environment (stage/prod) or pass an ad-hoc URL.
A failed lookup still fails the job, so the run never degrades into a
localhost check.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A2kiyUxRq2Dejzx4sDrNYB